### PR TITLE
Reposition call to action after strategic positioning

### DIFF
--- a/index.html
+++ b/index.html
@@ -553,44 +553,6 @@
     </div>
   </header>
 
-  <section class="cta-section" id="fluxo-pmo">
-    <div class="cta-card">
-      <span class="cta-tag">Seção de Chamada – Fluxo do PMO Educacross</span>
-      <h2>PMO Educacross: governança para transformar caos em orquestra</h2>
-      <p class="cta-intro">Quer entender como organizamos a entrada de demandas, priorizamos projetos e entregamos com previsibilidade? Desenvolvemos um fluxo único de ponta a ponta que une estratégia, tecnologia e pessoas para reduzir custos operacionais e escalar resultados.</p>
-      <div class="cta-highlights">
-        <h3>Principais destaques:</h3>
-        <ul>
-          <li>
-            <div class="highlight-icon">G0→G4</div>
-            <div class="highlight-content">
-              <strong>Governança com Stage Gates</strong>
-              <p>Decisões rápidas e eficientes do intake à estabilização e ao pós-projeto, com critérios claros em cada etapa.</p>
-            </div>
-          </li>
-          <li>
-            <div class="highlight-icon">RACI</div>
-            <div class="highlight-content">
-              <strong>Papéis e responsabilidades sem ruído</strong>
-              <p>Sponsor, Liderança, PMO, Gerentes de Projeto e Leads atuam com accountability definida — ninguém joga no escuro.</p>
-            </div>
-          </li>
-          <li>
-            <div class="highlight-icon">BI</div>
-            <div class="highlight-content">
-              <strong>Pipeline automatizado no Bitrix24</strong>
-              <p>Semáforo padrão, dashboards executivos e artefatos essenciais — tudo enxuto para gerar valor real, sem burocracia.</p>
-            </div>
-          </li>
-        </ul>
-      </div>
-      <div class="cta-footer">
-        <p>Se ficou curioso para conhecer o passo a passo, os critérios de cada Gate e o roadmap de implantação, clique em “Saiba Mais” e mergulhe na proposta completa.</p>
-        <a class="cta-button" href="#roadmap">Saiba Mais</a>
-      </div>
-    </div>
-  </section>
-
   <main>
     <section class="content-card" id="posicionamento">
       <span class="badge">Posicionamento do PMO</span>
@@ -601,6 +563,43 @@
           <li>Não é apenas execução operacional — planilhas, relatórios ou ajustes de documentos.</li>
           <li>É a área que conecta estratégia e execução, transformando iniciativas em resultados concretos.</li>
         </ul>
+      </div>
+    </section>
+
+    <section class="cta-section" id="fluxo-pmo">
+      <div class="cta-card">
+        <h2>PMO Educacross: governança para transformar caos em orquestra</h2>
+        <p class="cta-intro">Quer entender como organizamos a entrada de demandas, priorizamos projetos e entregamos com previsibilidade? Desenvolvemos um fluxo único de ponta a ponta que une estratégia, tecnologia e pessoas para reduzir custos operacionais e escalar resultados.</p>
+        <div class="cta-highlights">
+          <h3>Principais destaques:</h3>
+          <ul>
+            <li>
+              <div class="highlight-icon">G0→G4</div>
+              <div class="highlight-content">
+                <strong>Governança com Stage Gates</strong>
+                <p>Decisões rápidas e eficientes do intake à estabilização e ao pós-projeto, com critérios claros em cada etapa.</p>
+              </div>
+            </li>
+            <li>
+              <div class="highlight-icon">RACI</div>
+              <div class="highlight-content">
+                <strong>Papéis e responsabilidades sem ruído</strong>
+                <p>Sponsor, Liderança, PMO, Gerentes de Projeto e Leads atuam com accountability definida — ninguém joga no escuro.</p>
+              </div>
+            </li>
+            <li>
+              <div class="highlight-icon">BI</div>
+              <div class="highlight-content">
+                <strong>Pipeline automatizado no Bitrix24</strong>
+                <p>Semáforo padrão, dashboards executivos e artefatos essenciais — tudo enxuto para gerar valor real, sem burocracia.</p>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div class="cta-footer">
+          <p>Para conhecer o passo a passo, os critérios de cada Gate e o roadmap de implantação, consulte o material completo disponível em “Saiba Mais”.</p>
+          <a class="cta-button" href="#roadmap">Saiba Mais</a>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- move the call-to-action block to follow the strategic positioning section
- remove the section tag label and update the call-to-action copy for a more institutional tone

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd2a70e62c832aa94fedba6700b2b0