### PR TITLE
Adjust CTA spacing and remove objectives section

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,7 +317,7 @@
 
     .cta-section {
       position: relative;
-      margin: -40px auto 40px;
+      margin: 40px auto;
       max-width: 1100px;
       padding: 0 24px;
       z-index: 2;
@@ -599,29 +599,6 @@
         <div class="cta-footer">
           <p>Para conhecer o passo a passo, os critérios de cada Gate e o roadmap de implantação, consulte o material completo disponível em “Saiba Mais”.</p>
           <a class="cta-button" href="#roadmap">Saiba Mais</a>
-        </div>
-      </div>
-    </section>
-
-    <section class="content-card" id="objetivos">
-      <span class="badge">Objetivos Estratégicos</span>
-      <h2>Alinhamento direto com a diretoria</h2>
-      <div class="double-column">
-        <div>
-          <h3>Foco Raul — Redução de Custos</h3>
-          <ul>
-            <li>Padronização de processos para diminuir retrabalho e controles paralelos.</li>
-            <li>Gestão de riscos consistente para evitar custos com atrasos e correções.</li>
-            <li>Visão única de projetos, eliminando dispersão e duplicidade de esforço.</li>
-          </ul>
-        </div>
-        <div>
-          <h3>Foco Reginaldo — Expansão</h3>
-          <ul>
-            <li>Estrutura de governança para escalar novos contratos com segurança.</li>
-            <li>Onboarding ágil de novos clientes e projetos, com previsibilidade de entregas.</li>
-            <li>PMO como vitrine de profissionalismo, agregando valor em parcerias.</li>
-          </ul>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- increase the call-to-action section spacing to avoid overlapping the preceding card
- remove the strategic objectives section for Raul and Reginaldo from the proposal

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68dd2b9e67f4832aa8fb60b77e62c58f