### PR TITLE
Add fluxo PMO detail page

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -513,3 +513,205 @@ footer span {
   font-weight: 500;
   color: var(--primary);
 }
+
+/* Fluxo PMO page */
+.flow-body {
+  background: var(--background);
+  color: var(--text-dark);
+}
+
+.flow-header {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 96px 24px 48px;
+}
+
+.flow-breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.back-link {
+  color: var(--primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.version-chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  background: rgba(31, 75, 216, 0.1);
+  color: var(--primary-dark);
+  font-size: 0.9rem;
+  padding: 6px 14px;
+  font-weight: 500;
+}
+
+.flow-responsavel {
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.flow-header h1 {
+  margin: 18px 0 12px;
+  font-size: 2.4rem;
+  color: var(--primary-dark);
+}
+
+.flow-intro {
+  max-width: 840px;
+  color: var(--text-muted);
+}
+
+.flow-content {
+  max-width: 1100px;
+  margin: 0 auto 120px;
+  padding: 0 24px;
+}
+
+.flow-section {
+  background: var(--card-bg);
+  border-radius: 24px;
+  padding: 36px 40px;
+  margin-bottom: 28px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.flow-section h2 {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 1.5rem;
+  color: var(--primary-dark);
+  margin-bottom: 20px;
+}
+
+.flow-section h2 span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  background: rgba(31, 75, 216, 0.12);
+  color: var(--primary-dark);
+  font-weight: 600;
+}
+
+.flow-section h3 {
+  margin-top: 24px;
+  font-size: 1.2rem;
+  color: var(--primary);
+}
+
+.flow-section p {
+  color: var(--text-muted);
+  margin-bottom: 16px;
+}
+
+.flow-section ul,
+.flow-section ol {
+  margin-left: 1.2rem;
+  margin-bottom: 18px;
+  display: grid;
+  gap: 12px;
+}
+
+.flow-section ul {
+  list-style: disc;
+}
+
+.flow-section ol {
+  list-style: decimal;
+}
+
+.flow-section li {
+  color: var(--text-muted);
+}
+
+.flow-section a {
+  color: var(--primary);
+}
+
+.flow-section blockquote {
+  margin: 18px 0 0;
+  padding: 18px 20px;
+  border-left: 4px solid var(--primary);
+  background: rgba(31, 75, 216, 0.08);
+  color: var(--primary-dark);
+  border-radius: 0 16px 16px 0;
+}
+
+.link-list {
+  list-style: none;
+  margin-left: 0;
+}
+
+.link-list li {
+  padding: 12px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(31, 75, 216, 0.12);
+  background: rgba(31, 75, 216, 0.04);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+  margin-top: 24px;
+}
+
+.table-wrapper table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.table-wrapper th,
+.table-wrapper td {
+  padding: 16px;
+  text-align: left;
+  border-bottom: 1px solid rgba(31, 75, 216, 0.1);
+  color: var(--text-muted);
+}
+
+.table-wrapper th {
+  background: rgba(31, 75, 216, 0.08);
+  color: var(--primary-dark);
+  font-size: 0.95rem;
+}
+
+.flow-footer {
+  max-width: 1100px;
+  margin: 0 auto 80px;
+  padding: 0 24px;
+}
+
+.flow-footer p {
+  background: rgba(31, 75, 216, 0.08);
+  border-radius: 18px;
+  padding: 24px 28px;
+  color: var(--primary-dark);
+  font-weight: 500;
+}
+
+@media (max-width: 768px) {
+  .flow-header {
+    padding-top: 72px;
+  }
+
+  .flow-section {
+    padding: 28px;
+  }
+
+  .table-wrapper table {
+    min-width: 100%;
+  }
+}

--- a/fluxo-pmo/index.html
+++ b/fluxo-pmo/index.html
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fluxo do PMO Educacross</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/css/styles.css">
+</head>
+<body class="flow-body">
+  <div class="flow-header" role="banner">
+    <div class="flow-breadcrumb">
+      <a class="back-link" href="/">← Voltar para a visão geral</a>
+      <span class="version-chip">Versão 1.0 • Set/2025</span>
+    </div>
+    <p class="flow-responsavel"><strong>Responsável:</strong> Leonardo Fonseca Pontes (PMO)</p>
+    <h1>Fluxo do Escritório de Projetos (PMO) — Educacross</h1>
+    <p class="flow-intro">Fluxo integrado de ponta a ponta para intake, planejamento, execução e acompanhamento dos projetos Educacross, com governança baseada em Stage Gates e artefatos essenciais.</p>
+  </div>
+
+  <main class="flow-content">
+    <section class="flow-section" id="objetivo-principios">
+      <h2><span>0)</span> Objetivo e Princípios</h2>
+      <p>Criar um fluxo único, claro e mensurável de ponta a ponta (da entrada à operação e encerramento) para todos os projetos Educacross, reduzindo custos operacionais, aumentando previsibilidade de entregas e suportando expansão.</p>
+      <h3>Princípios</h3>
+      <ul>
+        <li><strong>Uma Fonte de Verdade:</strong> Bitrix24 como orquestrador de tarefas/fluxos; dashboards (Looker/Metabase) para visão executiva.</li>
+        <li><strong>Governança com <a href="https://www.notion.so/O-que-s-o-Stage-Gates-277e9f3bb81e80589759c9043334eed4?pvs=21" target="_blank" rel="noopener noreferrer">Stage Gates</a>:</strong> decisões em pontos de controle (Gates G0→G4) para foco e eficiência.</li>
+        <li><strong>Semáforo Executivo Padrão:</strong> mesmo critério para status e riscos em todos os projetos.</li>
+        <li><strong>Artefatos Essenciais, não Burocracia:</strong> mínimos necessários, padronizados, reutilizáveis.</li>
+      </ul>
+    </section>
+
+    <section class="flow-section" id="papeis-macro">
+      <h2><span>1)</span> Papéis Macro (RACI de alto nível)</h2>
+      <ul>
+        <li><strong>Sponsor/Comitê Executivo (Diretoria, p.ex. Reginaldo):</strong> aprova visão, orçamento e Gates; remove impedimentos críticos.</li>
+        <li><strong>Liderança Operacional (p.ex. Raul):</strong> priorização operacional, capacidade, ganhos de eficiência.</li>
+        <li><strong>PMO (Leonardo):</strong> define método, garante governança, planeja/acompanha portfólio, reporta status e riscos, cobra decisões nos Gates.</li>
+        <li><strong>Gerente de Projeto (GP):</strong> planejamento detalhado, execução, gestão de riscos/issues, comunicação.</li>
+        <li><strong>Leads de Área:</strong> Produto (Maxwell), Pedagógico (Erica), Operações (Raul), Marketing, Tecnologia (Douglas e Matheus B.), Financeiro (Angelita), Jurídico (Angelita), Suprimentos (Darlete), Relacionamento/CS (Paula Maria), etc.</li>
+      </ul>
+      <blockquote>Nota: A RACI detalhada por projeto será derivada deste macro, no artefato “RACI do Projeto”.</blockquote>
+    </section>
+
+    <section class="flow-section" id="visao-pipeline">
+      <h2><span>2)</span> Visão Geral do Pipeline</h2>
+      <p><strong>Fases &amp; Gates:</strong></p>
+      <ul class="link-list">
+        <li><a href="https://www.notion.so/Fluxo-do-Escrit-rio-de-Projetos-PMO-Educacross-277e9f3bb81e80e5a81bc16554c44efa?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Intake &amp; Triage → G0 (Aceitar para Descoberta?)</strong></a></li>
+        <li><a href="https://www.notion.so/Fluxo-do-Escrit-rio-de-Projetos-PMO-Educacross-277e9f3bb81e80e5a81bc16554c44efa?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Descoberta &amp; Iniciação → G1 (Aprovar Charter/Business Case?)</strong></a></li>
+        <li><a href="https://www.notion.so/Fluxo-do-Escrit-rio-de-Projetos-PMO-Educacross-277e9f3bb81e80e5a81bc16554c44efa?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Planejamento Detalhado → G2 (Plano pronto para Execução?)</strong></a></li>
+        <li><a href="https://www.notion.so/Fluxo-do-Escrit-rio-de-Projetos-PMO-Educacross-277e9f3bb81e80e5a81bc16554c44efa?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Execução &amp; Monitoramento → G3 (Go/No-Go para Lançamento?)</strong></a></li>
+        <li><a href="https://www.notion.so/Fluxo-do-Escrit-rio-de-Projetos-PMO-Educacross-277e9f3bb81e80e5a81bc16554c44efa?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Lançamento &amp; Estabilização → G4 (Encerrar? Transferir à Operação?)</strong></a></li>
+        <li><a href="https://www.notion.so/Fluxo-do-Escrit-rio-de-Projetos-PMO-Educacross-277e9f3bb81e80e5a81bc16554c44efa?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Pós-Projeto &amp; Benefícios (30/60/90 dias)</strong></a></li>
+      </ul>
+      <p>Cada Gate é um ponto de decisão que exige um conjunto mínimo de artefatos/condições para avançar.</p>
+    </section>
+
+    <section class="flow-section" id="g0">
+      <h2><span>3)</span> G0: Intake &amp; Triage (Entrada de Demanda)</h2>
+      <p><strong>Objetivo:</strong> Registrar, padronizar e classificar toda demanda (interna, cliente, parceiro) antes de consumir capacidade.</p>
+      <p><strong>Entradas típicas:</strong> Comercial/Parcerias; Diretoria; Produto; Operações; CS; Melhoria interna.</p>
+      <h3>Atividades-chave</h3>
+      <ol>
+        <li><a href="https://www.notion.so/G0-Ficha-de-Triagem-277e9f3bb81e80d4bd9cddb3b2138d7c?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Ficha de Triagem (Bitrix):</strong></a> cadastro único, com validações mínimas.</li>
+        <li><strong>Classificação Inicial:</strong> tipo (novo contrato, evolução, evento, melhoria); urgência; risco; estimativa alto nível; stakeholders.</li>
+        <li><strong>Triage:</strong> PMO + liderança da área avaliam viabilidade inicial e prioridade (score level).</li>
+        <li><strong>Decisão G0:</strong> aceitar para Descoberta ou rejeitar/postergar com justificativa.</li>
+      </ol>
+      <p><strong>Campos obrigatórios no <a href="https://www.notion.so/G0-Ficha-de-Triagem-277e9f3bb81e80d4bd9cddb3b2138d7c?pvs=21" target="_blank" rel="noopener noreferrer">Intake</a> (mínimos):</strong></p>
+      <ul>
+        <li>Nome do projeto; origem da demanda; sponsor; objetivo de negócio (1 frase); valor esperado (receita/eficiência/estratégia); prazo desejado; restrições; áreas impactadas; necessidade de compras/contratos; complexidade (baixa/média/alta); riscos óbvios.</li>
+      </ul>
+      <p><strong>Saídas/Artefatos:</strong> Registro de Demanda + Ficha de Triagem com decisão.</p>
+      <p><strong>SLA:</strong> triagem em até 5 dias úteis.</p>
+      <p><strong>Gate G0 – Critérios para avançar:</strong> objetivo claro e alinhado; sponsor identificado; janela temporal razoável; sem conflito crítico de capacidade; benefício preliminar plausível.</p>
+    </section>
+
+    <section class="flow-section" id="g1">
+      <h2><span>4)</span> G1: Descoberta &amp; Iniciação</h2>
+      <p><strong>Objetivo:</strong> Entender escopo em alto nível, estratégia, stakeholders e caminho de valor; formalizar a <a href="https://www.notion.so/G1-Carta-de-Abertura-277e9f3bb81e80d7b8a9d0b2cb786e60?pvs=21" target="_blank" rel="noopener noreferrer">Carta de Abertura</a>.</p>
+      <h3>Atividades-chave</h3>
+      <ol>
+        <li><a href="https://www.notion.so/G1-Kickoff-de-Descoberta-277e9f3bb81e808f9d77f039fc037743?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Kickoff de Descoberta:</strong></a> alinhar propósito, papéis e expectativas.</li>
+        <li><a href="https://www.notion.so/G1-Mapa-de-Stakeholders-277e9f3bb81e80648da5d78931501f1a?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Mapeamento de Stakeholders</strong></a> e comunicações iniciais.</li>
+        <li><a href="https://www.notion.so/G1-Business-Case-277e9f3bb81e80e5a455ddddc7281fa0?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Business Case (quando aplicável):</strong></a> hipótese de valor (receita, custo evitado, NPS, expansão).</li>
+        <li><a href="https://www.notion.so/G1-Escopo-de-Alto-N-vel-277e9f3bb81e80a0acbff0f860d1acb7?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Escopo de Alto Nível &amp; Critérios de Sucesso/OKRs.</strong></a></li>
+        <li><a href="https://www.notion.so/G2-Plano-de-Risco-277e9f3bb81e80e3a92ed379fec98477?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Riscos iniciais &amp; Assunções.</strong></a></li>
+        <li><a href="https://www.notion.so/G1-Carta-de-Abertura-277e9f3bb81e80d7b8a9d0b2cb786e60?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Carta de Abertura (Charter):</strong></a> visão, objetivos, escopo/fora de escopo, marcos macro, orçamento alvo, governança e Gate-plan.</li>
+        <li><a href="https://www.notion.so/G3-Plano-de-Comunica-o-277e9f3bb81e80b69dd5d7a4533d2773?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Plano Macro de Comunicação:</strong></a> cadências, audiências e canais.</li>
+        <li><a href="https://www.notion.so/G1-Defini-o-Preliminar-de-Dados-277e9f3bb81e8073954cd6e158c9aaef?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Definição preliminar de dados/indicadores:</strong></a> métricas para monitoramento do projeto e pós go-live.</li>
+      </ol>
+      <p><strong>Artefatos mínimos:</strong> Carta de Abertura; Mapa de Stakeholders; Business Case (quando aplicável); Plano Macro de Comunicação; Registro de Riscos Iniciais.</p>
+      <p><strong>Gate G1 – Critérios:</strong> Charter aprovado (Sponsor/Comitê); benefício e objetivos mensuráveis; riscos iniciais conhecidos; papéis definidos; marcos macro e orçamento alvo validados.</p>
+    </section>
+
+    <section class="flow-section" id="g2">
+      <h2><span>5)</span> G2: Planejamento Detalhado</h2>
+      <p><strong>Objetivo:</strong> Transformar o Charter em plano executável com responsabilidades, cronograma, orçamento, qualidade e riscos controlados.</p>
+      <h3>Atividades-chave</h3>
+      <ol>
+        <li><a href="https://www.notion.so/G2-EAP-WBS-277e9f3bb81e8084b200f6c24e1563e3?pvs=21" target="_blank" rel="noopener noreferrer"><strong>EAP/WBS e Pacotes de Trabalho</strong></a> → tarefas em Bitrix (templates por tipo de projeto).</li>
+        <li><a href="https://www.notion.so/G2-Cronograma-277e9f3bb81e80598f00ca873242174f?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Cronograma/Gantt</strong></a> com caminhos críticos e capacidade por time.</li>
+        <li><a href="https://www.notion.so/G2-Or-amento-Base-277e9f3bb81e80dfb555d7325df0c223?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Orçamento &amp; Centro de Custo</strong></a> (baseline; custos operacionais/fornecedores).</li>
+        <li><a href="https://www.notion.so/G2-Plano-de-Risco-277e9f3bb81e80e3a92ed379fec98477?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Riscos &amp; Issues:</strong></a> matriz probabilidade × impacto; planos de resposta; risk burndown alvo.</li>
+        <li><a href="https://www.notion.so/G2-Qualidade-Crit-rios-de-Aceite-277e9f3bb81e802f89a4eb6c3472f28c?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Qualidade &amp; Critérios de Aceite</strong></a> (por entrega).</li>
+        <li><a href="https://www.notion.so/G2-Plano-de-Aquisi-es-Suprimentos-277e9f3bb81e803da38ad0212ad9d908?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Plano de Aquisições/Suprimentos:</strong></a> escopo de compra, RFP/RFQ quando aplicável, antecedência mínima de 30 dias, homologação de fornecedores e SLA.</li>
+        <li><a href="https://www.notion.so/G2-Plano-Jur-dico-Contratos-277e9f3bb81e80ab91d4db870827b7e5?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Jurídico &amp; Contratos:</strong></a> NDAs, aditivos, licenças, marca/uso de imagem.</li>
+        <li><a href="https://www.notion.so/G2-Plano-de-Tecnologia-Dados-277e9f3bb81e80aab7b6c9db9509e213?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Tecnologia &amp; Dados:</strong></a> ambientes, integrações, segurança, definição do dashboard.</li>
+        <li><a href="https://www.notion.so/G2-Plano-Pedag-gico-Produto-277e9f3bb81e804ab0fae0073a0b0d32?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Pedagógico &amp; Produto:</strong></a> critérios de conteúdo, validações, QA instructional.</li>
+        <li><a href="https://www.notion.so/G2-Plano-de-Marketing-Comunica-o-277e9f3bb81e8079b5e1d5bea474682e?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Marketing &amp; Comunicação:</strong></a> plano de campanhas, press, assets visuais, calendário.</li>
+        <li><a href="https://www.notion.so/G2-Plano-de-Opera-o-Log-stica-277e9f3bb81e80ea9b45ce528e21a451?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Operações &amp; Logística:</strong></a> locais, fornecedores, transporte, materiais, checklists.</li>
+        <li><a href="https://www.notion.so/G2-Treinamento-Change-Management-277e9f3bb81e80aaafc6fea551ddb212?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Treinamento &amp; Change Management:</strong></a> plano de adoção (materiais, formações, suporte).</li>
+        <li><a href="https://www.notion.so/G2-Plano-de-Implanta-o-Rollback-277e9f3bb81e8027b8c1c2fd2fff82df?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Plano de Implantação &amp; Rollback:</strong></a> runbook, contingências, janela de lançamento.</li>
+        <li><a href="https://www.notion.so/G2-Plano-de-Testes-QA-277e9f3bb81e80beb4f1ca9f5232a65f?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Plano de Testes/QA:</strong></a> critérios de aprovação, cenários, evidências.</li>
+        <li><a href="https://www.notion.so/G2-Plano-de-Comunica-o-Detalhado-277e9f3bb81e8014b697c3f0f36210ef?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Plano de Comunicação Detalhado:</strong></a> cadências por público (interno/externo), DRI.</li>
+      </ol>
+      <p><strong>Artefatos mínimos:</strong> WBS; Cronograma; Orçamento baseline; Plano de Riscos/Issues; Plano de Qualidade; Plano de Aquisições; Plano Jurídico; Plano de Dados/Dashboard; Planos de Produto/Pedagógico/Operações/Marketing/Treinamento; Runbook/Rollback; Plano de Testes/QA; Plano de Comunicação Detalhado.</p>
+      <p><strong>Gate G2 – Critérios:</strong> WBS e cronograma viáveis e acordados; orçamento aprovado; riscos críticos com plano de resposta; fornecedores e contratos encaminhados; Definition of Ready para Execução atendida (ambientes, acessos, insumos, agenda confirmada; arte final aprovada, etc.).</p>
+    </section>
+
+    <section class="flow-section" id="g3">
+      <h2><span>6)</span> G3: Execução &amp; Monitoramento</h2>
+      <p><strong>Objetivo:</strong> Entregar escopo com qualidade, dentro do prazo e custo, controlando mudanças e riscos.</p>
+      <h3>Rituais (cadências mínimas)</h3>
+      <ul>
+        <li><strong>Daily/Weekly de Times:</strong> encontros curtos, focados em impedimentos e prioridades.</li>
+        <li><a href="https://www.notion.so/G3-Revis-o-Semanal-do-GP-PMO-277e9f3bb81e80249103f0a36d0e499d?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Revisão Semanal do GP/PMO:</strong></a> status, riscos/issues, decisões pendentes.</li>
+        <li><a href="https://www.notion.so/G3-Comit-de-Projeto-quinzenal-277e9f3bb81e8010ad9ae87dde1fed9c?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Comitê de Projeto (quinzenal):</strong></a> semaforização executiva, desvios, aprovações.</li>
+        <li><a href="https://www.notion.so/G3-Report-Executivo-quinzenal-mensal-277e9f3bb81e80e3acbcd61a639063aa?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Report Executivo (quinzenal/mensal):</strong></a> modelo aprovado de Status Report.</li>
+      </ul>
+      <h3>Controles</h3>
+      <ul>
+        <li><strong>Semáforo:</strong> Verde (±10% prazo/custo), Amarelo (&gt;10% ou risco alto), Vermelho (&gt;20% ou risco sem plano).</li>
+        <li><a href="https://www.notion.so/Change-Request-CR-Solicita-o-de-Mudan-a-277e9f3bb81e8094aec8d7fb1785f2b2?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Mudanças (Change Requests):</strong></a> registro de impacto e aprovação em Comitê.</li>
+        <li><a href="https://www.notion.so/G2-Plano-de-Risco-277e9f3bb81e80e3a92ed379fec98477?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Risco &amp; Issue Review:</strong></a> semanal, com responsáveis e datas.</li>
+        <li><a href="https://www.notion.so/G2-Plano-de-Testes-QA-277e9f3bb81e80beb4f1ca9f5232a65f?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Qualidade/QA:</strong></a> evidências de testes e aceite por entrega.</li>
+        <li><a href="https://www.notion.so/G3-Plano-de-Gest-o-de-Fornecedores-277e9f3bb81e8062ac0ecb9df76a5779?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Gestão de Fornecedores:</strong></a> SLA, aceite de entregáveis, conformidade.</li>
+      </ul>
+      <p><strong>Gate G3 – Checklist Go/No-Go:</strong> testes aprovados; comunicação pronta (interna/externa); jurídico/contratos ok; operação treinada; suporte/atendimento alinhado; finanças/configurações de faturamento ok; plano de rollback revisado; janela de implantação confirmada.</p>
+    </section>
+
+    <section class="flow-section" id="g4">
+      <h2><span>7)</span> G4: Lançamento &amp; Estabilização</h2>
+      <p><strong>Objetivo:</strong> Colocar em produção/evento, estabilizar, medir e transferir para operação.</p>
+      <h3>Atividades-chave</h3>
+      <ol>
+        <li><strong>Go-Live/Evento</strong> conforme <a href="https://www.notion.so/G4-Runbook-277e9f3bb81e80baa0f5e4cb9a9a3a2c?pvs=21" target="_blank" rel="noopener noreferrer">runbook</a>; war-room se necessário.</li>
+        <li><strong>Monitoramento intensivo (1ª - 2ª semana):</strong> SLAs, incidentes, hotfixes, KPIs.</li>
+        <li><strong>Coleta de feedback:</strong> clientes, parceiros, times internos.</li>
+        <li><strong>Ajustes rápidos (fast-follow):</strong> priorização conjunta GP/PMO.</li>
+        <li><strong>Handover para Operação/CS:</strong> playbooks, responsáveis, SLAs contínuos.</li>
+      </ol>
+      <p><strong>Gate G4 – Critérios para Encerramento:</strong> KPIs mínimos atingidos; incidentes críticos resolvidos ou com plano claro; operação assumiu o runbook; faturamento/financeiro regularizado; documentação arquivada.</p>
+    </section>
+
+    <section class="flow-section" id="pos-projeto">
+      <h2><span>8)</span> Encerramento &amp; Pós-Projeto (30/60/90)</h2>
+      <p><strong>Objetivo:</strong> Consolidar aprendizados, comprovar benefícios e formalizar término.</p>
+      <h3>Atividades-chave</h3>
+      <ul>
+        <li><a href="https://www.notion.so/G4-Aceites-do-Sponsor-277e9f3bb81e80ab98decc5560f4413d?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Termo de Aceite do Sponsor/Cliente.</strong></a></li>
+        <li><strong>Fechamento Financeiro &amp; Contratual:</strong> liquidação, aditivos, notas.</li>
+        <li><a href="https://www.notion.so/G4-Li-es-Aprendidas-277e9f3bb81e80a2b05ef2bf086b4518?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Lições Aprendidas</strong></a> (post-mortem com ações de melhoria).</li>
+        <li><a href="https://www.notion.so/G4-Avalia-o-de-Benef-cios-30-60-90-dias-277e9f3bb81e8021b0f7e1eac62a233a?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Avaliação de Benefícios (30/60/90 dias):</strong></a> receita ativada, custo evitado, NPS, adoção/uso.</li>
+        <li><strong>Reconhecimento do Time</strong> e comunicação de encerramento.</li>
+        <li><strong>Arquivamento &amp; Indexação</strong> (repositório padrão; nomeação de arquivos).</li>
+      </ul>
+      <p><strong>Saídas:</strong> Relatório Final do Projeto; registro de benefícios; backlog de melhorias para portfólio.</p>
+    </section>
+
+    <section class="flow-section" id="governanca-portfolio">
+      <h2><span>9)</span> Governança de Portfólio</h2>
+      <ul>
+        <li><a href="https://www.notion.so/Comit-de-Port-lio-Educacross-277e9f3bb81e80ecbb6de3bef41c418c?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Comitê de Portfólio (mensal):</strong></a> visão do conjunto de projetos; priorização; alocação de capacidade; trade-offs custo × valor.</li>
+        <li><a href="https://www.notion.so/Radar-de-Riscos-de-Porf-lio-Educacross-277e9f3bb81e8032a10ef06f23b70302?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Radar de Riscos de Portfólio:</strong></a> top-3 riscos transversais; decisões executivas.</li>
+        <li><a href="https://www.notion.so/Roadmap-Trimestra-Educacross-277e9f3bb81e80dbbc5dd68a202ce7c8?pvs=21" target="_blank" rel="noopener noreferrer"><strong>Roadmap Trimestral:</strong></a> janelas de lançamento/eventos; dependências.</li>
+      </ul>
+      <h3>Indicadores de Portfólio (exemplos)</h3>
+      <ul>
+        <li><strong>Eficiência (Raul):</strong> % on-time; lead time médio por tipo de projeto; esforço gasto em retrabalho; custo evitado estimado; ocupação de capacidade por time.</li>
+        <li><strong>Expansão (Reginaldo):</strong> receita contratada/ativada; tempo de onboarding; NPS; % entregas com valor demonstrado (case/vitrine).</li>
+      </ul>
+    </section>
+
+    <section class="flow-section" id="artefatos-por-area">
+      <h2><span>10)</span> Artefatos por Área (Mapa para detalhamento posterior)</h2>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Área</th>
+              <th>Artefatos Essenciais (mínimo viável)</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><strong>PMO/GP</strong></td>
+              <td>Formulário Intake; Ficha de Triage; Charter; Plano de Comunicação; WBS; Cronograma; Orçamento; Plano de Riscos/Issues; Plano de Qualidade; Plano de Implantação/Rollback; Relatórios de Status (modelo semáforo); Relatório Final.</td>
+            </tr>
+            <tr>
+              <td><strong>Produto</strong></td>
+              <td>Documento de Requisitos; Backlog priorizado; Critérios de Aceite; Protótipos; Plano de Releases.</td>
+            </tr>
+            <tr>
+              <td><strong>Pedagógico</strong></td>
+              <td>Escopo didático; Matriz de validação; Rubricas de qualidade; Plano de formação/conteúdo.</td>
+            </tr>
+            <tr>
+              <td><strong>Tecnologia</strong></td>
+              <td>Arquitetura; Plano de Integrações/SSO/APIs; Plano de Testes (dev/QA); Evidências; Runbooks.</td>
+            </tr>
+            <tr>
+              <td><strong>Operações</strong></td>
+              <td>Plano logístico; Checklists por evento; Mapa de recursos; Plano de contingência.</td>
+            </tr>
+            <tr>
+              <td><strong>Marketing</strong></td>
+              <td>Plano de Comunicação; Briefings; Artes/Assets; Calendário de mídia; PR.</td>
+            </tr>
+            <tr>
+              <td><strong>Financeiro</strong></td>
+              <td>Plano orçamentário; Centros de custo; Aprovações; Fluxo de faturamento.</td>
+            </tr>
+            <tr>
+              <td><strong>Jurídico</strong></td>
+              <td>NDAs; Contratos; Autorizações de marca/imagem; Compliance.</td>
+            </tr>
+            <tr>
+              <td><strong>Suprimentos</strong></td>
+              <td>Escopo de compras; Cotações; Comparativo técnico-comercial; Pedidos; SLA fornecedores.</td>
+            </tr>
+            <tr>
+              <td><strong>Relacionamento/CS</strong></td>
+              <td>Plano de onboarding; Playbooks de atendimento; SLAs; Pesquisa de satisfação.</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>Próximo passo: detalhar templates e critérios de qualidade de cada artefato (MVP → padrão corporativo).</p>
+    </section>
+
+    <section class="flow-section" id="bitrix">
+      <h2><span>11)</span> Bitrix24 – Estrutura e Automações Recomendadas</h2>
+      <p><strong>Tipos de Projeto (custom field):</strong> Evento; Implantação Cliente; Parceria/Whitelabel; Evolução Produto; Melhoria Interna.</p>
+      <p><strong>Pipeline (Kanban) sugerido:</strong> Intake → Descoberta → Planejamento → Execução → Lançamento/Estabilização → Encerramento.</p>
+      <h3>Automações por fase (exemplos)</h3>
+      <ul>
+        <li><strong>Ao entrar em Descoberta:</strong> criar tarefas-filhas Kickoff, Stakeholders, Charter.</li>
+        <li><strong>Ao entrar em Planejamento:</strong> criar tarefas-filhas WBS, Cronograma, Orçamento, Riscos, Aquisições, Jurídico, Dados/Dashboard, Marketing, Operações, Treinamento, QA/Testes, Runbook/Rollback.</li>
+        <li><strong>Ao entrar em Execução:</strong> agendar rituais; iniciar Status Report quinzenal (tarefa recorrente).</li>
+        <li><strong>Ao mover para Lançamento:</strong> disparar Checklist Go/No-Go e notificar Sponsor/Comitê.</li>
+        <li><strong>Ao encerrar:</strong> gerar Relatório Final + tarefa de Benefícios 30/60/90.</li>
+      </ul>
+      <h3>Campos obrigatórios por Gate</h3>
+      <ul>
+        <li><strong>G1:</strong> Carta de Abertura anexada; objetivos/KPIs definidos; sponsor confirmado.</li>
+        <li><strong>G2:</strong> WBS/Cronograma aprovados; orçamento baseline; planos críticos anexados; Definition of Ready ok.</li>
+        <li><strong>G3:</strong> evidências de QA; comunicação aprovada; suporte treinado; janela confirmada; rollback definido.</li>
+        <li><strong>G4:</strong> KPIs mínimos; handover assinado; finanças ok; documentação arquivada.</li>
+      </ul>
+    </section>
+
+    <section class="flow-section" id="politicas">
+      <h2><span>12)</span> Políticas e Padrões</h2>
+      <ul>
+        <li><strong>Definition of Ready (Execução):</strong> requisitos claros; dependências resolvidas; recursos agendados; contratos emitidos; ambientes prontos.</li>
+        <li><strong>Definition of Done (Entregas):</strong> critérios de aceite atendidos; evidências anexadas; comunicação feita; impactos em documentação refletidos.</li>
+        <li><strong>Controle de Mudanças:</strong> toda alteração relevante de escopo/prazo/custo passa por CR com aprovação no Comitê.</li>
+        <li><strong>Nomeação &amp; Repositório:</strong> padrão de nomes; local único por tipo de artefato; versão/controle.</li>
+        <li><strong>Semáforo Padrão:</strong> alinhado ao modelo Educacross aprovado para status de escopo, prazo, qualidade técnica, relacionamento, risco comercial, situação contratual.</li>
+      </ul>
+    </section>
+
+    <section class="flow-section" id="implantacao">
+      <h2><span>13)</span> Implantação do PMO (Roadmap)</h2>
+      <ul>
+        <li><strong>0–30 dias:</strong> ativar Intake/Triage; adotar Carta de Abertura padrão; iniciar semáforo e report executivo; mapear projetos ativos.</li>
+        <li><strong>30–60 dias:</strong> habilitar automações no Bitrix; publicar templates MVP; painel de portfólio em Looker/Metabase.</li>
+        <li><strong>60–90 dias:</strong> instituir Comitê de Portfólio; padronizar Go/No-Go; ciclo de benefícios 30/60/90.</li>
+      </ul>
+    </section>
+
+    <section class="flow-section" id="apendices">
+      <h2><span>14)</span> Apêndices (para detalhar na sequência)</h2>
+      <ul>
+        <li><strong>A.</strong> Checklists por Gate (G0→G4)</li>
+        <li><strong>B.</strong> Catálogo de Templates (todos os artefatos)</li>
+        <li><strong>C.</strong> Glossário de Termos</li>
+        <li><strong>D.</strong> Matriz de Riscos Padrão (catálogos e respostas-tipo)</li>
+        <li><strong>E.</strong> Critérios de KPIs por tipo de projeto (Evento, Implantação, Whitelabel, Evolução Produto etc.)</li>
+      </ul>
+    </section>
+  </main>
+
+  <footer class="flow-footer">
+    <p><strong>Mensagem-chave para Diretoria:</strong> Este fluxo substitui “ações pontuais” por governança e disciplina de valor, equilibrando eficiência (redução de retrabalho/custos) e expansão (previsibilidade e vitrine para o mercado).</p>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
         PMO Educacross
       </div>
       <div class="nav-actions">
-        <a href="#roadmap">Roadmap 90 dias</a>
+        <a href="/fluxo-pmo/">Roadmap 90 dias</a>
       </div>
     </div>
     <div class="hero">
@@ -82,7 +82,7 @@
         </div>
         <div class="cta-footer">
           <p>Para conhecer o passo a passo, os critérios de cada Gate e o roadmap de implantação, consulte o material completo disponível em “Saiba Mais”.</p>
-          <a class="cta-button" href="#roadmap">Saiba Mais</a>
+          <a class="cta-button" href="/fluxo-pmo/">Saiba Mais</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- link the "Saiba Mais" CTA to a new /fluxo-pmo route
- create the fluxo PMO page with the complete stage-gate flow content
- extend shared styles to support the new long-form documentation layout

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dd31e482e4832abdea6eda1ca1046f