### PR TITLE
Refactor fluxo side navigation

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -141,6 +141,7 @@
   --spacing-list-indent: 1.2rem;
   --layout-container: 1100px;
   --layout-container-wide: 1180px;
+  --topbar-offset: var(--space-48);
 
   --space-6: var(--spacing-2xs);
   --space-8: var(--spacing-xs);
@@ -953,6 +954,18 @@ footer span {
   box-shadow: var(--shadow-card-accent-hover);
 }
 
+.flow-main-layout {
+  display: block;
+}
+
+.flow-main-content {
+  display: block;
+}
+
+.flow-side-nav {
+  display: none;
+}
+
 .flow-quick-nav {
   position: relative;
   margin-top: calc(-1 * var(--spacing-section));
@@ -1146,7 +1159,88 @@ footer span {
   box-shadow: var(--shadow-card-hero);
 }
 
+@media (min-width: 768px) {
+  .flow-main-layout {
+    max-width: var(--layout-container-wide);
+    margin: 0 auto var(--spacing-section-xl);
+    padding: 0 var(--spacing-3xl-plus);
+    display: grid;
+    grid-template-columns: minmax(200px, 260px) minmax(0, 1fr);
+    column-gap: var(--space-32);
+    align-items: start;
+  }
+
+  .flow-main-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-32);
+  }
+
+  .flow-side-nav {
+    display: block;
+    position: sticky;
+    top: var(--topbar-offset);
+    align-self: start;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-24);
+    box-shadow: var(--shadow-card-subtle);
+    max-height: calc(100vh - var(--topbar-offset) - var(--space-32));
+    overflow-y: auto;
+    scrollbar-width: thin;
+  }
+
+  .flow-side-nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-16);
+  }
+
+  .flow-side-nav li {
+    display: block;
+  }
+
+  .flow-side-nav a {
+    display: block;
+    padding: var(--space-12) var(--space-18);
+    border-radius: var(--radius-sm);
+    color: var(--color-text-muted);
+    text-decoration: none;
+    font-weight: 500;
+    font-size: var(--font-size-sm-plus);
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .flow-side-nav a:hover,
+  .flow-side-nav a:focus {
+    background: var(--color-primary-tint-soft);
+    color: var(--color-primary-dark);
+    box-shadow: inset 0 0 0 1px var(--color-primary-tint-strong);
+  }
+
+  .flow-side-nav a.active {
+    background: var(--color-primary-tint-soft);
+    color: var(--color-primary-dark);
+    box-shadow: inset 0 0 0 2px var(--color-primary-tint-strong);
+  }
+
+  .flow-quick-nav {
+    display: none;
+  }
+
+  .flow-content {
+    max-width: none;
+    margin: 0;
+    padding: 0;
+  }
+}
+
 @media (max-width: 960px) {
+
   .flow-hero {
     padding-bottom: var(--spacing-section-xxl);
   }
@@ -1165,6 +1259,16 @@ footer span {
 
   .flow-section {
     padding: var(--spacing-4xl) var(--spacing-3xl-plus);
+  }
+}
+
+@media (min-width: 768px) and (max-width: 960px) {
+  .flow-main-layout {
+    padding: 0 var(--spacing-gutter);
+  }
+
+  .flow-side-nav {
+    padding: var(--space-20);
   }
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -3,5 +3,83 @@
 'use strict';
 
 document.addEventListener("DOMContentLoaded", () => {
-  // Inicializações futuras podem ser adicionadas aqui.
+  const sideNav = document.querySelector(".flow-side-nav");
+  if (!sideNav) {
+    return;
+  }
+
+  const navLinks = Array.from(sideNav.querySelectorAll("a[data-section]"));
+  if (!navLinks.length) {
+    return;
+  }
+
+  const sections = navLinks
+    .map((link) => {
+      const sectionId = link.dataset.section || link.getAttribute("href").replace("#", "");
+      const sectionEl = sectionId ? document.getElementById(sectionId) : null;
+      if (sectionEl) {
+        link.dataset.section = sectionId;
+      }
+      return sectionEl;
+    })
+    .filter(Boolean);
+
+  if (!sections.length) {
+    return;
+  }
+
+  const setActiveLink = (sectionId) => {
+    navLinks.forEach((link) => {
+      if (link.dataset.section === sectionId) {
+        link.classList.add("active");
+        link.setAttribute("aria-current", "true");
+      } else {
+        link.classList.remove("active");
+        link.removeAttribute("aria-current");
+      }
+    });
+  };
+
+  const observerOptions = {
+    root: null,
+    rootMargin: "-35% 0px -45% 0px",
+    threshold: [0.25, 0.5, 0.75],
+  };
+
+  const observer = new IntersectionObserver((entries) => {
+    const visibleSections = entries
+      .filter((entry) => entry.isIntersecting)
+      .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
+
+    if (visibleSections.length > 0) {
+      setActiveLink(visibleSections[0].target.id);
+      return;
+    }
+
+    const aboveViewport = entries
+      .filter((entry) => entry.boundingClientRect.top < 0)
+      .sort((a, b) => b.boundingClientRect.top - a.boundingClientRect.top);
+
+    if (aboveViewport.length > 0) {
+      setActiveLink(aboveViewport[0].target.id);
+    }
+  }, observerOptions);
+
+  sections.forEach((section) => observer.observe(section));
+
+  const initialId = window.location.hash
+    ? window.location.hash.substring(1)
+    : sections[0].id;
+  if (initialId) {
+    setActiveLink(initialId);
+  }
+
+  navLinks.forEach((link) => {
+    link.addEventListener("click", () => {
+      const sectionId = link.dataset.section;
+      if (sectionId) {
+        setActiveLink(sectionId);
+      }
+    });
+  });
 });

--- a/fluxo-pmo/index.html
+++ b/fluxo-pmo/index.html
@@ -60,26 +60,47 @@
     </div>
   </header>
 
-  <nav class="flow-quick-nav" aria-label="Navegação pelas seções do fluxo">
-    <ul>
-      <li><a href="#objetivo-principios">Objetivo</a></li>
-      <li><a href="#papeis-macro">Papéis</a></li>
-      <li><a href="#visao-pipeline">Pipeline</a></li>
-      <li><a href="#g0">G0</a></li>
-      <li><a href="#g1">G1</a></li>
-      <li><a href="#g2">G2</a></li>
-      <li><a href="#g3">G3</a></li>
-      <li><a href="#g4">G4</a></li>
-      <li><a href="#pos-projeto">Pós-Projeto</a></li>
-      <li><a href="#governanca-portfolio">Portfólio</a></li>
-      <li><a href="#artefatos-por-area">Artefatos</a></li>
-      <li><a href="#bitrix">Bitrix24</a></li>
-      <li><a href="#politicas">Políticas</a></li>
-      <li><a href="#implantacao">Implantação</a></li>
-    </ul>
-  </nav>
+  <div class="flow-main-layout">
+    <nav class="flow-side-nav" aria-label="Índice do fluxo">
+      <ul>
+        <li><a class="flow-side-link" href="#objetivo-principios" data-section="objetivo-principios">Objetivo</a></li>
+        <li><a class="flow-side-link" href="#papeis-macro" data-section="papeis-macro">Papéis</a></li>
+        <li><a class="flow-side-link" href="#visao-pipeline" data-section="visao-pipeline">Pipeline</a></li>
+        <li><a class="flow-side-link" href="#g0" data-section="g0">G0</a></li>
+        <li><a class="flow-side-link" href="#g1" data-section="g1">G1</a></li>
+        <li><a class="flow-side-link" href="#g2" data-section="g2">G2</a></li>
+        <li><a class="flow-side-link" href="#g3" data-section="g3">G3</a></li>
+        <li><a class="flow-side-link" href="#g4" data-section="g4">G4</a></li>
+        <li><a class="flow-side-link" href="#pos-projeto" data-section="pos-projeto">Pós-Projeto</a></li>
+        <li><a class="flow-side-link" href="#governanca-portfolio" data-section="governanca-portfolio">Portfólio</a></li>
+        <li><a class="flow-side-link" href="#artefatos-por-area" data-section="artefatos-por-area">Artefatos</a></li>
+        <li><a class="flow-side-link" href="#bitrix" data-section="bitrix">Bitrix24</a></li>
+        <li><a class="flow-side-link" href="#politicas" data-section="politicas">Políticas</a></li>
+        <li><a class="flow-side-link" href="#implantacao" data-section="implantacao">Implantação</a></li>
+      </ul>
+    </nav>
 
-  <main class="flow-content">
+    <div class="flow-main-content">
+      <nav class="flow-quick-nav" aria-label="Navegação pelas seções do fluxo">
+        <ul>
+          <li><a href="#objetivo-principios">Objetivo</a></li>
+          <li><a href="#papeis-macro">Papéis</a></li>
+          <li><a href="#visao-pipeline">Pipeline</a></li>
+          <li><a href="#g0">G0</a></li>
+          <li><a href="#g1">G1</a></li>
+          <li><a href="#g2">G2</a></li>
+          <li><a href="#g3">G3</a></li>
+          <li><a href="#g4">G4</a></li>
+          <li><a href="#pos-projeto">Pós-Projeto</a></li>
+          <li><a href="#governanca-portfolio">Portfólio</a></li>
+          <li><a href="#artefatos-por-area">Artefatos</a></li>
+          <li><a href="#bitrix">Bitrix24</a></li>
+          <li><a href="#politicas">Políticas</a></li>
+          <li><a href="#implantacao">Implantação</a></li>
+        </ul>
+      </nav>
+
+      <main class="flow-content">
     <section class="flow-section" id="objetivo-principios">
       <h2><span>0)</span> Objetivo e Princípios</h2>
       <p>Criar um fluxo único, claro e mensurável de ponta a ponta (da entrada à operação e encerramento) para todos os projetos Educacross, reduzindo custos operacionais, aumentando previsibilidade de entregas e suportando expansão.</p>
@@ -353,10 +374,14 @@
         <li><strong>E.</strong> Critérios de KPIs por tipo de projeto (Evento, Implantação, Whitelabel, Evolução Produto etc.)</li>
       </ul>
     </section>
-  </main>
+      </main>
+    </div>
+  </div>
 
   <footer class="flow-footer">
     <p><strong>Mensagem-chave para Diretoria:</strong> Este fluxo substitui “ações pontuais” por governança e disciplina de valor, equilibrando eficiência (redução de retrabalho/custos) e expansão (previsibilidade e vitrine para o mercado).</p>
   </footer>
+
+  <script src="../assets/js/main.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a sticky vertical side navigation to the fluxo PMO page and copy the quick nav anchors with accessible hooks
- restyle the layout for desktop, hiding the horizontal quick nav, and apply token-based styling to the new index
- implement a vanilla JS scroll spy to sync the active state and load the script on the page

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd45a02b8c832aa0c7cb26d18d326e