### PR TITLE
fix: prevent Vercel builds from failing with next export

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'export',
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "node scripts/build.js",
     "start": "next start"
   },
   "dependencies": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+
+const run = (command) => {
+  execSync(command, {
+    stdio: 'inherit',
+    env: process.env,
+  });
+};
+
+run('next build');
+
+if (process.env.VERCEL) {
+  console.log('\nDetected Vercel environment. Skipping `next export` and relying on Next.js static output.');
+} else {
+  console.log('\nBuild complete. Static files are available in the `out` directory.');
+}


### PR DESCRIPTION
## Summary
- configure Next.js to rely on the built-in static export mode instead of invoking `next export`
- add a Node-based build script that skips the extra export step when running on Vercel
- update the build npm script to call the new helper

## Testing
- not run (npm registry access is blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd6af286fc832aae26635c3655c8ea