### PR TITLE
Remove obsolete header and hero actions

### DIFF
--- a/components/Header.jsx
+++ b/components/Header.jsx
@@ -90,11 +90,6 @@ export default function Header() {
           </li>
         </ul>
       </nav>
-      <div className="nav-actions">
-        <Link href="/fluxo-pmo" className="btn btn-secondary">
-          Roadmap 90 dias
-        </Link>
-      </div>
     </div>
   );
 }

--- a/pages/fluxo-pmo/index.js
+++ b/pages/fluxo-pmo/index.js
@@ -124,19 +124,10 @@ export default function FluxoPMO() {
             <span className="flow-brand-mark">educacross</span>
             <span className="flow-brand-tag">PMO</span>
           </a>
-          <nav className="flow-top-actions" aria-label="Navegação primária">
-            <Link className="btn btn-secondary" href="/">
-              Visão geral
-            </Link>
-            <a className="btn btn-secondary" href="#implantacao">
-              Implantação
-            </a>
-          </nav>
         </div>
 
         <div className="flow-hero-main">
           <div className="flow-hero-text">
-            <span className="flow-pill">Escritório de Projetos</span>
             <h1>Fluxo integrado do PMO Educacross</h1>
             <p>
               Fluxo de ponta a ponta para intake, planejamento, execução e acompanhamento dos projetos Educacross, com

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -455,10 +455,6 @@ header::after {
   box-shadow: inset 0 0 0 1px var(--color-white-outline-strong);
 }
 
-.nav-actions .btn {
-  font-size: clamp(1.17rem, 1.05rem + 0.4vw, 1.25rem);
-}
-
 .hero {
   max-width: var(--layout-container);
   margin: 0 auto;
@@ -928,19 +924,6 @@ footer span {
   color: var(--color-white-dim);
 }
 
-.flow-top-actions {
-  display: flex;
-  gap: var(--spacing-md-plus);
-  flex-wrap: wrap;
-}
-
-.flow-top-actions .btn {
-  padding: var(--spacing-sm-plus) var(--spacing-xl);
-  border-radius: var(--radius-md);
-  letter-spacing: 0.3px;
-  font-size: clamp(1.17rem, 1.05rem + 0.4vw, 1.25rem);
-}
-
 .flow-hero-main {
   max-width: var(--layout-container-wide);
   margin: 0 auto;
@@ -956,21 +939,8 @@ footer span {
 .flow-hero-text h1 {
   font-size: var(--font-size-display);
   line-height: 1.15;
+  margin-top: 0;
   margin-bottom: var(--spacing-lg-plus);
-}
-
-.flow-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-sm);
-  padding: var(--spacing-xs) var(--spacing-card-gap);
-  border-radius: var(--radius-pill);
-  background: var(--color-white-glass);
-  font-size: var(--font-size-xs);
-  letter-spacing: 1.4px;
-  text-transform: uppercase;
-  margin-bottom: var(--spacing-card-gap);
-  box-shadow: inset 0 0 0 1px var(--color-white-outline-ghost);
 }
 
 .flow-hero-text p {
@@ -1431,16 +1401,6 @@ footer span {
     align-items: flex-start;
     gap: var(--spacing-card-gap);
     padding: 0 var(--spacing-gutter);
-  }
-
-  .flow-top-actions {
-    width: 100%;
-  }
-
-  .flow-top-actions .btn {
-    flex: 1 1 auto;
-    justify-content: center;
-    text-align: center;
   }
 
   .flow-hero-main {


### PR DESCRIPTION
## Summary
- remove the duplicated hero pill and legacy quick links from the Fluxo PMO page
- drop the Roadmap 90 dias call-to-action from the global header
- clean up unused styles and normalize the hero heading spacing after the removals

## Testing
- Attempted `npm install` *(fails: registry access returns 403 so the project cannot be started in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd70be449c832aa95b27b383132fc1