### PR TITLE
Enable trailing slash export for PMO flow route

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  trailingSlash: true,
+};
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- enable Next.js trailingSlash option so static exports create directory-style paths

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68dd724c8b6c832a89bffc76377abcd3