### PR TITLE
feat: redesign global navigation header

### DIFF
--- a/pages/404.js
+++ b/pages/404.js
@@ -1,6 +1,5 @@
 import Head from 'next/head';
 import Link from 'next/link';
-import Header from '../components/Header';
 
 export default function NotFoundPage() {
   return (
@@ -9,11 +8,15 @@ export default function NotFoundPage() {
         <title>Página não encontrada - PMO Educacross</title>
       </Head>
       <header className="page-header-minimal">
-        <Header />
+        <div className="page-header-minimal__inner">
+          <h1>Página não encontrada</h1>
+          <p className="page-header-minimal__lead">
+            A rota acessada não existe. Utilize o menu principal ou retorne para a página inicial.
+          </p>
+        </div>
       </header>
       <main className="simple-page">
-        <h1>Página não encontrada</h1>
-        <p>A rota acessada não existe. Utilize o menu principal ou retorne para a página inicial.</p>
+        <p>Use o menu principal ou o botão a seguir para retornar à página inicial.</p>
         <Link href="/" className="btn btn-primary">
           Voltar para Home
         </Link>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,6 @@
 import Head from 'next/head';
 import '../styles/globals.css';
+import Header from '../components/Header';
 
 export default function App({ Component, pageProps }) {
   return (
@@ -13,6 +14,7 @@ export default function App({ Component, pageProps }) {
           rel="stylesheet"
         />
       </Head>
+      <Header />
       <Component {...pageProps} />
     </>
   );

--- a/pages/fluxo-pmo/index.js
+++ b/pages/fluxo-pmo/index.js
@@ -1,7 +1,6 @@
 import Head from 'next/head';
 import Link from 'next/link';
 import { useEffect, useRef } from 'react';
-import Header from '../../components/Header';
 
 export default function FluxoPMO() {
   const navContainerRef = useRef(null);
@@ -118,7 +117,6 @@ export default function FluxoPMO() {
         />
       </Head>
       <header className="flow-hero" role="banner">
-        <Header />
         <div className="flow-topbar">
           <a className="flow-brand" href="https://educacross.com.br" target="_blank" rel="noopener noreferrer">
             <span className="flow-brand-mark">educacross</span>

--- a/pages/g0.js
+++ b/pages/g0.js
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Header from '../components/Header';
 
 export default function G0Page() {
   return (
@@ -9,10 +8,11 @@ export default function G0Page() {
         <meta name="description" content="Resumo da fase G0 do fluxo do PMO Educacross." />
       </Head>
       <header className="page-header-minimal">
-        <Header />
+        <div className="page-header-minimal__inner">
+          <h1>G0 — Intake &amp; Triage</h1>
+        </div>
       </header>
       <main className="simple-page">
-        <h1>G0 — Intake &amp; Triage</h1>
         <p>Conteúdo detalhado da fase G0 será adicionado em breve.</p>
       </main>
     </>

--- a/pages/g1.js
+++ b/pages/g1.js
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Header from '../components/Header';
 
 export default function G1Page() {
   return (
@@ -9,10 +8,11 @@ export default function G1Page() {
         <meta name="description" content="Resumo da fase G1 do fluxo do PMO Educacross." />
       </Head>
       <header className="page-header-minimal">
-        <Header />
+        <div className="page-header-minimal__inner">
+          <h1>G1 — Descoberta &amp; Iniciação</h1>
+        </div>
       </header>
       <main className="simple-page">
-        <h1>G1 — Descoberta &amp; Iniciação</h1>
         <p>Conteúdo detalhado da fase G1 será adicionado em breve.</p>
       </main>
     </>

--- a/pages/g2.js
+++ b/pages/g2.js
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Header from '../components/Header';
 
 export default function G2Page() {
   return (
@@ -9,10 +8,11 @@ export default function G2Page() {
         <meta name="description" content="Resumo da fase G2 do fluxo do PMO Educacross." />
       </Head>
       <header className="page-header-minimal">
-        <Header />
+        <div className="page-header-minimal__inner">
+          <h1>G2 — Planejamento Detalhado</h1>
+        </div>
       </header>
       <main className="simple-page">
-        <h1>G2 — Planejamento Detalhado</h1>
         <p>Conteúdo detalhado da fase G2 será adicionado em breve.</p>
       </main>
     </>

--- a/pages/g3.js
+++ b/pages/g3.js
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Header from '../components/Header';
 
 export default function G3Page() {
   return (
@@ -9,10 +8,11 @@ export default function G3Page() {
         <meta name="description" content="Resumo da fase G3 do fluxo do PMO Educacross." />
       </Head>
       <header className="page-header-minimal">
-        <Header />
+        <div className="page-header-minimal__inner">
+          <h1>G3 — Execução &amp; Monitoramento</h1>
+        </div>
       </header>
       <main className="simple-page">
-        <h1>G3 — Execução &amp; Monitoramento</h1>
         <p>Conteúdo detalhado da fase G3 será adicionado em breve.</p>
       </main>
     </>

--- a/pages/g4.js
+++ b/pages/g4.js
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Header from '../components/Header';
 
 export default function G4Page() {
   return (
@@ -9,10 +8,11 @@ export default function G4Page() {
         <meta name="description" content="Resumo da fase G4 do fluxo do PMO Educacross." />
       </Head>
       <header className="page-header-minimal">
-        <Header />
+        <div className="page-header-minimal__inner">
+          <h1>G4 — Lançamento &amp; Estabilização</h1>
+        </div>
       </header>
       <main className="simple-page">
-        <h1>G4 — Lançamento &amp; Estabilização</h1>
         <p>Conteúdo detalhado da fase G4 será adicionado em breve.</p>
       </main>
     </>

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,6 +1,5 @@
 import Head from 'next/head';
 import Link from 'next/link';
-import Header from '../components/Header';
 
 export default function Home() {
   return (
@@ -12,8 +11,7 @@ export default function Home() {
           content="Visão geral do PMO Educacross com governança, metodologia e roadmap de implantação."
         />
       </Head>
-      <header>
-        <Header />
+      <header className="page-hero">
         <div className="hero">
           <div className="hero-text">
             <div className="hero-highlight">Estratégia • Governança • Resultados</div>

--- a/pages/instrumentos/g0.js
+++ b/pages/instrumentos/g0.js
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Header from '../../components/Header';
 
 export default function InstrumentoG0Page() {
   return (
@@ -9,10 +8,11 @@ export default function InstrumentoG0Page() {
         <meta name="description" content="Instrumentos da fase G0 do PMO Educacross." />
       </Head>
       <header className="page-header-minimal">
-        <Header />
+        <div className="page-header-minimal__inner">
+          <h1>Instrumentos — G0</h1>
+        </div>
       </header>
       <main className="simple-page">
-        <h1>Instrumentos — G0</h1>
         <p>Os instrumentos específicos para a fase G0 serão publicados em breve.</p>
       </main>
     </>

--- a/pages/instrumentos/g1.js
+++ b/pages/instrumentos/g1.js
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Header from '../../components/Header';
 
 export default function InstrumentoG1Page() {
   return (
@@ -9,10 +8,11 @@ export default function InstrumentoG1Page() {
         <meta name="description" content="Instrumentos da fase G1 do PMO Educacross." />
       </Head>
       <header className="page-header-minimal">
-        <Header />
+        <div className="page-header-minimal__inner">
+          <h1>Instrumentos — G1</h1>
+        </div>
       </header>
       <main className="simple-page">
-        <h1>Instrumentos — G1</h1>
         <p>Os instrumentos específicos para a fase G1 serão publicados em breve.</p>
       </main>
     </>

--- a/pages/instrumentos/g2.js
+++ b/pages/instrumentos/g2.js
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Header from '../../components/Header';
 
 export default function InstrumentoG2Page() {
   return (
@@ -9,10 +8,11 @@ export default function InstrumentoG2Page() {
         <meta name="description" content="Instrumentos da fase G2 do PMO Educacross." />
       </Head>
       <header className="page-header-minimal">
-        <Header />
+        <div className="page-header-minimal__inner">
+          <h1>Instrumentos — G2</h1>
+        </div>
       </header>
       <main className="simple-page">
-        <h1>Instrumentos — G2</h1>
         <p>Os instrumentos específicos para a fase G2 serão publicados em breve.</p>
       </main>
     </>

--- a/pages/instrumentos/g3.js
+++ b/pages/instrumentos/g3.js
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Header from '../../components/Header';
 
 export default function InstrumentoG3Page() {
   return (
@@ -9,10 +8,11 @@ export default function InstrumentoG3Page() {
         <meta name="description" content="Instrumentos da fase G3 do PMO Educacross." />
       </Head>
       <header className="page-header-minimal">
-        <Header />
+        <div className="page-header-minimal__inner">
+          <h1>Instrumentos — G3</h1>
+        </div>
       </header>
       <main className="simple-page">
-        <h1>Instrumentos — G3</h1>
         <p>Os instrumentos específicos para a fase G3 serão publicados em breve.</p>
       </main>
     </>

--- a/pages/instrumentos/g4.js
+++ b/pages/instrumentos/g4.js
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import Header from '../../components/Header';
 
 export default function InstrumentoG4Page() {
   return (
@@ -9,10 +8,11 @@ export default function InstrumentoG4Page() {
         <meta name="description" content="Instrumentos da fase G4 do PMO Educacross." />
       </Head>
       <header className="page-header-minimal">
-        <Header />
+        <div className="page-header-minimal__inner">
+          <h1>Instrumentos — G4</h1>
+        </div>
       </header>
       <main className="simple-page">
-        <h1>Instrumentos — G4</h1>
         <p>Os instrumentos específicos para a fase G4 serão publicados em breve.</p>
       </main>
     </>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -142,6 +142,7 @@
   --layout-container: 1100px;
   --layout-container-wide: 1180px;
   --topbar-offset: var(--space-48);
+  --header-height: 78px;
 
   --space-6: var(--spacing-2xs);
   --space-8: var(--spacing-xs);
@@ -286,7 +287,7 @@ button:focus-visible,
   pointer-events: none;
 }
 
-header {
+.page-hero {
   background: var(--gradient-hero);
   color: var(--color-white);
   padding: var(--spacing-6xl) 0 var(--spacing-section-lg);
@@ -294,8 +295,8 @@ header {
   overflow: hidden;
 }
 
-header::before,
-header::after {
+.page-hero::before,
+.page-hero::after {
   content: "";
   position: absolute;
   border-radius: var(--radius-circle);
@@ -303,115 +304,18 @@ header::after {
   filter: blur(0.5px);
 }
 
-header::before {
+.page-hero::before {
   width: 420px;
   height: 420px;
   top: calc(-1 * var(--spacing-section-max));
   right: calc(-1 * var(--spacing-section-xl));
 }
 
-header::after {
+.page-hero::after {
   width: 320px;
   height: 320px;
   bottom: calc(-1 * var(--spacing-section-hero));
   left: calc(-1 * var(--spacing-section-snug));
-}
-
-.top-bar {
-  max-width: var(--layout-container);
-  margin: 0 auto var(--spacing-8xl);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: var(--spacing-5xl);
-  padding: 0 var(--spacing-gutter);
-}
-
-.main-nav {
-  flex: 1;
-}
-
-.main-nav > ul {
-  list-style: none;
-  display: flex;
-  gap: var(--spacing-2xl-plus);
-  margin: 0;
-  padding: 0;
-  align-items: center;
-}
-
-.main-nav__link,
-.submenu__link,
-.submenu-label {
-  font-weight: 500;
-  color: var(--color-white);
-  text-decoration: none;
-  font-size: var(--font-size-sm-strong);
-  transition: color 0.2s ease;
-}
-
-.main-nav__link:hover,
-.submenu__link:hover,
-.main-nav__link:focus-visible,
-.submenu__link:focus-visible {
-  color: var(--color-accent-light);
-}
-
-.main-nav__link.active,
-.submenu__link.active,
-.has-submenu.active > .submenu-label {
-  color: var(--color-accent-light);
-}
-
-.has-submenu {
-  position: relative;
-}
-
-.submenu-label {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--spacing-2xs);
-  cursor: default;
-}
-
-.submenu {
-  display: none;
-  position: absolute;
-  top: calc(100% + var(--spacing-sm));
-  left: 0;
-  background: var(--color-primary-tint-soft);
-  backdrop-filter: blur(12px);
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-md-plus) var(--spacing-2xl);
-  list-style: none;
-  box-shadow: 0 18px 35px rgba(var(--color-primary-rgb), 0.25);
-  min-width: 160px;
-  z-index: 10;
-}
-
-.submenu li + li {
-  margin-top: var(--spacing-sm-plus);
-}
-
-.has-submenu:hover > .submenu,
-.has-submenu:focus-within > .submenu {
-  display: block;
-}
-
-.flow-hero > .top-bar {
-  max-width: var(--layout-container-wide);
-  padding: 0 var(--spacing-3xl-plus);
-  margin-bottom: var(--spacing-6xl);
-}
-
-.page-header-minimal {
-  background: var(--gradient-hero);
-  color: var(--color-white);
-  padding: var(--spacing-6xl) 0 var(--spacing-6xl);
-}
-
-.page-header-minimal .top-bar {
-  margin-bottom: 0;
 }
 
 .simple-page {
@@ -432,27 +336,6 @@ header::after {
 
 .simple-page .btn {
   margin-top: var(--spacing-3xl);
-}
-
-.brand {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-sm-plus);
-  font-weight: 600;
-  font-size: var(--font-size-lg);
-  letter-spacing: 0.5px;
-}
-
-.brand span {
-  display: inline-flex;
-  width: 46px;
-  height: 46px;
-  border-radius: var(--radius-xs);
-  background: var(--color-white-pill);
-  align-items: center;
-  justify-content: center;
-  font-size: var(--font-size-xl);
-  box-shadow: inset 0 0 0 1px var(--color-white-outline-strong);
 }
 
 .hero {
@@ -1480,3 +1363,485 @@ footer span {
     transition-duration: 0.01ms !important;
   }
 }
+.site-header {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  z-index: 1000;
+  background: linear-gradient(
+    135deg,
+    rgba(var(--color-primary-rgb), 0.98),
+    rgba(var(--color-secondary-rgb), 0.92)
+  );
+  color: var(--color-white);
+  border-bottom: 1px solid var(--color-white-outline);
+  box-shadow: 0 18px 32px rgba(var(--color-primary-rgb), 0.28);
+  backdrop-filter: blur(18px);
+}
+
+.site-header__inner {
+  max-width: var(--layout-container-wide);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-32);
+  padding: var(--space-12) var(--space-24);
+  min-height: var(--header-height);
+}
+
+.site-header__brand {
+  display: flex;
+  align-items: center;
+}
+
+.brand-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-12);
+  font-weight: 600;
+  font-size: var(--font-size-base-plus);
+  letter-spacing: 0.4px;
+  color: var(--color-white);
+  text-decoration: none;
+  border-radius: var(--radius-pill);
+  padding: var(--space-10) var(--space-14);
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.brand-link:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-outline);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(140deg, rgba(var(--color-accent-rgb), 0.9), rgba(255, 255, 255, 0.15));
+  border: 1px solid var(--color-white-outline-strong);
+  font-weight: 700;
+  font-size: var(--font-size-lg);
+  letter-spacing: 0.08em;
+  color: var(--color-accent-light);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+}
+
+.brand-text {
+  display: inline-flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.brand-text::after {
+  content: 'Governança & Resultados';
+  font-size: var(--font-size-xs);
+  font-weight: 400;
+  color: var(--color-white-light);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.site-nav {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.site-nav__list {
+  display: flex;
+  align-items: center;
+  gap: var(--space-26);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.site-nav__item {
+  position: relative;
+}
+
+.site-nav__link,
+.site-nav__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-8);
+  padding: var(--space-10) var(--space-16);
+  font-weight: 500;
+  font-size: var(--font-size-sm-strong);
+  letter-spacing: 0.02em;
+  color: var(--color-white);
+  text-decoration: none;
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition: color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+}
+
+.site-nav__link:focus-visible,
+.site-nav__toggle:focus-visible,
+.site-nav__link:hover,
+.site-nav__toggle:hover {
+  outline: none;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--color-accent-light);
+}
+
+.site-nav__item.is-active > .site-nav__link,
+.site-nav__item.is-active > .site-nav__toggle {
+  background: rgba(255, 255, 255, 0.16);
+  color: var(--color-accent-light);
+}
+
+.site-nav__toggle {
+  padding-right: var(--space-22);
+}
+
+.site-nav__toggle::after {
+  content: '';
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 6px solid currentColor;
+  transition: transform 0.2s ease;
+}
+
+.site-nav__item.is-open > .site-nav__toggle::after,
+.site-nav__item:hover > .site-nav__toggle::after,
+.site-nav__item:focus-within > .site-nav__toggle::after {
+  transform: rotate(-180deg);
+}
+
+.site-nav__submenu {
+  position: absolute;
+  top: calc(100% + var(--space-12));
+  left: 0;
+  min-width: 220px;
+  background: rgba(14, 26, 78, 0.92);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-white-outline);
+  padding: var(--space-16) var(--space-22);
+  list-style: none;
+  margin: 0;
+  box-shadow: 0 22px 45px rgba(10, 20, 66, 0.32);
+  opacity: 0;
+  transform: translateY(-6px);
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.site-nav__submenu-item + .site-nav__submenu-item {
+  margin-top: var(--space-12);
+}
+
+.site-nav__submenu-link {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-12);
+  padding: var(--space-10) var(--space-14);
+  font-weight: 500;
+  color: var(--color-white);
+  text-decoration: none;
+  border-radius: var(--radius-md);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.site-nav__submenu-link:hover,
+.site-nav__submenu-link:focus-visible {
+  outline: none;
+  background: rgba(var(--color-accent-rgb), 0.18);
+  color: var(--color-accent-light);
+}
+
+.site-nav__submenu-link.is-active {
+  background: rgba(var(--color-accent-rgb), 0.22);
+  color: var(--color-accent-light);
+}
+
+.site-nav__item.is-open > .site-nav__submenu,
+.site-nav__item:hover > .site-nav__submenu,
+.site-nav__item:focus-within > .site-nav__submenu {
+  opacity: 1;
+  transform: translateY(0);
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.site-header__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-16);
+}
+
+.site-header__actions .btn {
+  white-space: nowrap;
+  box-shadow: 0 12px 28px rgba(var(--color-accent-rgb), 0.25);
+}
+
+.menu-toggle {
+  display: none;
+  position: relative;
+  width: 46px;
+  height: 44px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-white-outline);
+  background: rgba(255, 255, 255, 0.06);
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.menu-toggle:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-outline);
+}
+
+.menu-toggle__line {
+  display: block;
+  width: 22px;
+  height: 2px;
+  border-radius: var(--radius-pill);
+  background: var(--color-white);
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.site-header.is-open .menu-toggle__line:nth-child(1) {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.site-header.is-open .menu-toggle__line:nth-child(2) {
+  opacity: 0;
+}
+
+.site-header.is-open .menu-toggle__line:nth-child(3) {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+.site-nav__item--cta {
+  display: none;
+}
+
+.site-header__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(7, 14, 48, 0.58);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  z-index: 999;
+}
+
+.site-header.is-open .site-header__overlay {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.page-header-minimal {
+  background: var(--gradient-hero);
+  color: var(--color-white);
+  padding: calc(var(--space-64) + var(--space-24)) 0 var(--space-56);
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.page-header-minimal::before,
+.page-header-minimal::after {
+  content: '';
+  position: absolute;
+  border-radius: var(--radius-circle);
+  background: var(--color-white-translucent);
+  filter: blur(0.5px);
+}
+
+.page-header-minimal::before {
+  width: 320px;
+  height: 320px;
+  top: -160px;
+  right: -180px;
+}
+
+.page-header-minimal::after {
+  width: 260px;
+  height: 260px;
+  bottom: -140px;
+  left: -160px;
+}
+
+.page-header-minimal__inner {
+  max-width: var(--layout-container);
+  margin: 0 auto;
+  padding: 0 var(--spacing-gutter);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-14);
+  align-items: center;
+  text-align: center;
+}
+
+.page-header-minimal__inner h1 {
+  font-size: var(--font-size-heading-md);
+  margin: 0;
+}
+
+.page-header-minimal__lead {
+  max-width: 640px;
+  font-size: var(--font-size-body-lg);
+  color: var(--color-white-medium);
+  margin: 0;
+}
+
+@media (max-width: 1100px) {
+  .site-header__inner {
+    gap: var(--space-20);
+    padding-inline: var(--space-20);
+  }
+
+  .site-nav__list {
+    gap: var(--space-20);
+  }
+}
+
+@media (max-width: 920px) {
+  .brand-text::after {
+    content: none;
+  }
+
+  .brand-link {
+    padding: var(--space-8) var(--space-12);
+  }
+}
+
+@media (max-width: 768px) {
+  :root {
+    --header-height: 72px;
+  }
+
+  .site-header__inner {
+    gap: var(--space-16);
+  }
+
+  .site-nav {
+    position: fixed;
+    inset: var(--header-height) 0 0;
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
+    padding: var(--space-36) var(--space-24) var(--space-48);
+    background: rgba(10, 16, 48, 0.94);
+    backdrop-filter: blur(20px);
+    transform: translateY(-6%);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    z-index: 1001;
+  }
+
+  .site-header.is-open .site-nav {
+    transform: translateY(0);
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+  }
+
+  .site-nav__list {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-20);
+    width: 100%;
+  }
+
+  .site-nav__item {
+    width: 100%;
+  }
+
+  .site-nav__link,
+  .site-nav__toggle {
+    width: 100%;
+    justify-content: space-between;
+    padding: var(--space-12) var(--space-16);
+    font-size: var(--font-size-base);
+  }
+
+  .site-nav__toggle {
+    padding-right: var(--space-16);
+  }
+
+  .site-nav__toggle::after {
+    margin-left: var(--space-12);
+  }
+
+  .site-nav__submenu {
+    position: static;
+    margin-top: var(--space-12);
+    padding: var(--space-12) var(--space-16);
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--color-white-outline);
+    box-shadow: none;
+    opacity: 1;
+    transform: none;
+    visibility: visible;
+    pointer-events: auto;
+    display: none;
+    gap: var(--space-10);
+  }
+
+  .site-nav__item.has-submenu.is-open > .site-nav__submenu {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .site-nav__item.has-submenu:not(.is-open) > .site-nav__submenu {
+    display: none;
+  }
+
+  .site-nav__submenu-link {
+    padding: var(--space-10) var(--space-12);
+    font-size: var(--font-size-sm-strong);
+  }
+
+  .site-header__actions .btn {
+    display: none;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
+  }
+
+  .site-nav__item--cta {
+    display: block;
+  }
+
+  .site-nav__item--cta .btn {
+    width: 100%;
+    justify-content: center;
+  }
+}
+


### PR DESCRIPTION
## Summary
- replace the Header component with a responsive, accessible navigation that maps menu items from configuration data and adds a CTA
- add global styles for the sticky header, dropdowns, and mobile drawer while updating page hero/minimal headers to host their titles
- mount the new Header from _app.js and update existing pages to rely on the shared layout

## Testing
- npm run build *(fails: `next` binary is not available in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd72e29668832a9b5cb26d06250bc4