### PR TITLE
Add Educacross projects footer with dynamic year

### DIFF
--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function Footer() {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer className="site-footer">
+      <div className="site-footer__inner">
+        <p className="site-footer__text">
+          © {currentYear} Time de Projetos Educacross. Todos os direitos reservados.
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,7 @@
 import Head from 'next/head';
 import '../styles/globals.css';
 import Header from '../components/Header';
+import Footer from '../components/Footer';
 
 export default function App({ Component, pageProps }) {
   return (
@@ -16,6 +17,7 @@ export default function App({ Component, pageProps }) {
       </Head>
       <Header />
       <Component {...pageProps} />
+      <Footer />
     </>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1616,6 +1616,28 @@ footer span {
   transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
+.site-footer {
+  margin-top: var(--space-64);
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.site-footer__inner {
+  max-width: var(--layout-container);
+  margin: 0 auto;
+  padding: 0 var(--spacing-gutter);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+.site-footer__text {
+  margin: 0;
+}
+
 .site-header.is-open .menu-toggle__line:nth-child(1) {
   transform: translateY(6px) rotate(45deg);
 }


### PR DESCRIPTION
## Summary
- add a global footer component that displays the Educacross projects team rights notice with the current year
- include the footer in the shared application layout so it appears on every page
- style the footer to align with the existing design system spacing and typography

## Testing
- npm install *(fails: 403 Forbidden - unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68dd785d15e8832abebfe287b78685ab