### PR TITLE
Align callout list bullets

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -461,6 +461,36 @@ main {
   margin-top: var(--spacing-card-gap);
 }
 
+.callout ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: block;
+}
+
+.callout ul li {
+  position: relative;
+  padding-left: 28px;
+  margin: 0 0 var(--spacing-sm);
+  line-height: 1.45;
+}
+
+.callout ul li:last-child {
+  margin-bottom: 0;
+}
+
+.callout ul li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.6em;
+  transform: translateY(-50%);
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background-color: var(--color-accent);
+}
+
 .double-column {
   display: grid;
   gap: var(--spacing-xl);


### PR DESCRIPTION
## Summary
- reset the default list styling for callout sections
- add custom bullet markers and spacing so callout list items align cleanly with their text

## Testing
- npm install *(fails: 403 Forbidden fetching packages from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68dd79889884832ab3060c8ed48cb5dc