### PR TITLE
Add Stage Gates overview page and link from pipeline

### DIFF
--- a/pages/stage-gates.js
+++ b/pages/stage-gates.js
@@ -1,0 +1,141 @@
+import Head from 'next/head';
+import Link from 'next/link';
+
+import Callout from '../src/components/common/Callout';
+import ContentCard from '../src/components/common/ContentCard';
+import Layout from '../src/components/layout/Layout';
+
+export default function StageGatesPage() {
+  const hero = (
+    <header className="page-header-minimal">
+      <div className="page-header-minimal__inner">
+        <h1>Stage Gates</h1>
+        <p className="page-header-minimal__lead">
+          Checkpoints oficiais que mantêm a disciplina entre estratégia, execução e captura de benefícios.
+        </p>
+      </div>
+    </header>
+  );
+
+  const pageTitle = 'Stage Gates – PMO Educacross';
+  const pageDescription =
+    'Entenda como os Stage Gates estruturam decisões, entregáveis e checkpoints do fluxo do PMO Educacross.';
+
+  return (
+    <>
+      <Head>
+        <title>{pageTitle}</title>
+        <meta name="description" content={pageDescription} />
+      </Head>
+      <Layout hero={hero}>
+        <section className="simple-page stage-gates-page">
+          <ContentCard id="introducao">
+            <h2>O que são Stage Gates?</h2>
+            <p>
+              Stage Gates são pontos de controle formais ao longo do ciclo de vida de um projeto. Em cada gate, o time e a
+              liderança avaliam se os objetivos, riscos, recursos e entregáveis estão prontos para liberar a próxima fase,
+              funcionando como checkpoints oficiais para garantir foco e priorização.
+            </p>
+          </ContentCard>
+
+          <ContentCard id="por-que">
+            <h2>Por que usamos Stage Gates?</h2>
+            <ul className="stage-gates-benefits">
+              <li>
+                <strong>🚦 Organização:</strong> traz visibilidade sobre prioridades, evita dispersão de esforços e mantém o
+                portfólio sob governança.
+              </li>
+              <li>
+                <strong>⚙️ Eficiência:</strong> só avançamos quando os pré-requisitos estão prontos, reduzindo retrabalhos e
+                alocando melhor a capacidade dos times.
+              </li>
+              <li>
+                <strong>🤝 Alinhamento:</strong> consolida patrocinadores, líderes e squads com expectativas claras sobre
+                escopo, sucesso e responsabilidades.
+              </li>
+              <li>
+                <strong>🔍 Transparência:</strong> decisões, riscos e próximos passos ficam documentados, facilitando o
+                acompanhamento executivo.
+              </li>
+            </ul>
+          </ContentCard>
+
+          <ContentCard id="como-funciona">
+            <h2>Como funciona na Educacross</h2>
+            <ol className="stage-gates-steps">
+              <li>
+                <strong>G0 – Intake &amp; Triage</strong>
+                <p>
+                  <strong>Decisão:</strong> Vale investir tempo da equipe para estruturar a descoberta?
+                </p>
+                <p>
+                  <strong>Entregáveis:</strong> Demanda registrada e priorizada, sponsor definido e hipótese de valor
+                  mapeada.
+                </p>
+              </li>
+              <li>
+                <strong>G1 – Descoberta &amp; Iniciação</strong>
+                <p>
+                  <strong>Decisão:</strong> Charter e Business Case aprovados para planejar em detalhe?
+                </p>
+                <p>
+                  <strong>Entregáveis:</strong> Charter validado, análise de viabilidade, escopo macro e time núcleo
+                  confirmados.
+                </p>
+              </li>
+              <li>
+                <strong>G2 – Planejamento Detalhado</strong>
+                <p>
+                  <strong>Decisão:</strong> Plano integrado pronto para execução?
+                </p>
+                <p>
+                  <strong>Entregáveis:</strong> Cronograma detalhado, orçamento consolidado, matriz de riscos e plano de
+                  comunicação alinhados.
+                </p>
+              </li>
+              <li>
+                <strong>G3 – Execução &amp; Monitoramento</strong>
+                <p>
+                  <strong>Decisão:</strong> Produto ou serviço preparado para implantação/piloto controlado?
+                </p>
+                <p>
+                  <strong>Entregáveis:</strong> Entregas validadas, readiness checklist completo e plano de implantação com
+                  responsáveis.
+                </p>
+              </li>
+              <li>
+                <strong>G4 – Lançamento &amp; Estabilização</strong>
+                <p>
+                  <strong>Decisão:</strong> Aprovar o encerramento e seguir para medições pós-implantação?
+                </p>
+                <p>
+                  <strong>Entregáveis:</strong> Resultados 30/60/90 dias, lições aprendidas, termo de encerramento e plano de
+                  sustentação.
+                </p>
+              </li>
+            </ol>
+          </ContentCard>
+
+          <ContentCard id="visual-resumido">
+            <h2>Visual resumido</h2>
+            <pre className="stage-gates-flow">[Ideia/Demanda] → G0 → G1 → G2 → G3 → G4 → [Benefícios 30/60/90 dias]</pre>
+          </ContentCard>
+
+          <ContentCard id="resumo">
+            <Callout title="Resumo final">
+              <p>
+                Stage Gates são pontos de decisão obrigatórios que disciplinam a evolução dos projetos, equilibrando eficiência
+                operacional e expansão sustentável do portfólio.
+              </p>
+            </Callout>
+            <div className="stage-gates-actions">
+              <Link href="/fluxo-pmo" className="btn btn-secondary">
+                Voltar ao Fluxo
+              </Link>
+            </div>
+          </ContentCard>
+        </section>
+      </Layout>
+    </>
+  );
+}

--- a/src/components/flow/flowSectionsData.js
+++ b/src/components/flow/flowSectionsData.js
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 const flowSections = [
   {
     id: 'objetivo-principios',
@@ -126,6 +128,11 @@ const flowSections = [
             >
               <strong>Lançamento &amp; Estabilização → G4 (Aprovar Encerramento?)</strong>
             </a>
+          </li>
+          <li>
+            <Link href="/stage-gates">
+              <strong>O que são Stage&nbsp;Gates?</strong>
+            </Link>
           </li>
         </ul>
       </>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -293,6 +293,110 @@ button:focus-visible,
   background-color: var(--color-accent);
 }
 
+.stage-gates-page {
+  display: grid;
+  gap: var(--space-32);
+}
+
+.stage-gates-page .content-card {
+  margin: 0;
+}
+
+.stage-gates-benefits {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-16) 0 0;
+  display: grid;
+  gap: var(--space-18);
+}
+
+.stage-gates-benefits li {
+  padding-left: 0;
+  font-size: var(--font-size-body-lg);
+}
+
+.stage-gates-benefits li::before {
+  display: none;
+}
+
+.stage-gates-benefits strong {
+  color: var(--color-primary-dark);
+  font-weight: 600;
+}
+
+.stage-gates-steps {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-24) 0 0;
+  display: grid;
+  gap: var(--space-24);
+  counter-reset: stage-gate -1;
+}
+
+.stage-gates-steps li {
+  background: var(--color-surface-soft);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-2xl);
+  padding: var(--space-24);
+  box-shadow: var(--shadow-card-soft);
+  color: var(--color-text-muted);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}
+
+.stage-gates-steps li::before {
+  counter-increment: stage-gate;
+  content: 'G' counter(stage-gate);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 46px;
+  border-radius: var(--radius-pill);
+  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+  color: var(--color-white);
+  font-weight: 700;
+  font-size: var(--font-size-lg);
+  margin-bottom: var(--space-8);
+}
+
+.stage-gates-steps li > strong {
+  font-size: var(--font-size-heading-xs);
+  color: var(--color-primary-dark);
+}
+
+.stage-gates-steps li p {
+  margin: 0;
+  font-size: var(--font-size-body);
+  line-height: 1.55;
+}
+
+.stage-gates-steps li p strong {
+  color: var(--color-primary);
+}
+
+.stage-gates-flow {
+  margin-top: var(--space-20);
+  padding: var(--space-20);
+  background: var(--color-surface-soft);
+  border: 1px dashed var(--color-border-contrast);
+  border-radius: var(--radius-2xl);
+  font-family: 'DM Mono', 'Fira Code', 'Source Code Pro', 'Menlo', 'Monaco', monospace;
+  font-size: var(--font-size-body-lg);
+  text-align: center;
+  color: var(--color-primary-dark);
+  overflow-x: auto;
+}
+
+.stage-gates-actions {
+  margin-top: var(--space-24);
+}
+
+.stage-gates-actions .btn {
+  margin-top: 0;
+}
+
 .double-column {
   display: grid;
   gap: var(--spacing-xl);


### PR DESCRIPTION
## Summary
- add a dedicated Stage Gates page that follows the existing layout and explains checkpoints, benefits, etapas e resumo visual
- surface a new internal link to the Stage Gates explanation inside the "Visão Geral do Pipeline" section of the fluxo PMO
- extend global styles so the new page reuses content-card visuals with tailored lists, steps and visual summary formatting

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd80bfb32c832ab661f1b41ad507b8