### PR TITLE
Improve mobile navigation menu readability

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1716,8 +1716,9 @@ footer span {
     align-items: flex-start;
     justify-content: flex-start;
     padding: var(--space-36) var(--space-24) var(--space-48);
-    background: rgba(10, 16, 48, 0.94);
-    backdrop-filter: blur(20px);
+    background: var(--color-surface);
+    color: var(--color-text);
+    box-shadow: 0 22px 45px rgba(10, 20, 66, 0.2);
     transform: translateY(-6%);
     opacity: 0;
     visibility: hidden;
@@ -1750,6 +1751,8 @@ footer span {
     justify-content: space-between;
     padding: var(--space-12) var(--space-16);
     font-size: var(--font-size-base);
+    color: var(--color-text);
+    background: transparent;
   }
 
   .site-nav__toggle {
@@ -1760,13 +1763,27 @@ footer span {
     margin-left: var(--space-12);
   }
 
+  .site-nav__link:focus-visible,
+  .site-nav__toggle:focus-visible,
+  .site-nav__link:hover,
+  .site-nav__toggle:hover {
+    background: rgba(var(--color-primary-rgb), 0.12);
+    color: var(--color-primary);
+  }
+
+  .site-nav__item.is-active > .site-nav__link,
+  .site-nav__item.is-active > .site-nav__toggle {
+    background: rgba(var(--color-primary-rgb), 0.16);
+    color: var(--color-primary);
+  }
+
   .site-nav__submenu {
     position: static;
     margin-top: var(--space-12);
     padding: var(--space-12) var(--space-16);
-    background: rgba(255, 255, 255, 0.08);
+    background: var(--color-surface-soft);
     border-radius: var(--radius-md);
-    border: 1px solid var(--color-white-outline);
+    border: 1px solid var(--color-border);
     box-shadow: none;
     opacity: 1;
     transform: none;
@@ -1788,6 +1805,18 @@ footer span {
   .site-nav__submenu-link {
     padding: var(--space-10) var(--space-12);
     font-size: var(--font-size-sm-strong);
+    color: var(--color-text);
+  }
+
+  .site-nav__submenu-link:hover,
+  .site-nav__submenu-link:focus-visible {
+    background: rgba(var(--color-primary-rgb), 0.12);
+    color: var(--color-primary);
+  }
+
+  .site-nav__submenu-link.is-active {
+    background: rgba(var(--color-primary-rgb), 0.16);
+    color: var(--color-primary);
   }
 
   .site-header__actions .btn {


### PR DESCRIPTION
## Summary
- Switch the mobile navigation drawer to a solid surface background with dark text for proper contrast
- Update hover and active states, including submenu styling, to use the primary palette for better legibility

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68dd8798813c832a80e508d4fe227097