### PR TITLE
Align custom bullets in structure section

### DIFF
--- a/src/components/home/StructureSection.jsx
+++ b/src/components/home/StructureSection.jsx
@@ -13,7 +13,7 @@ export default function StructureSection() {
       <div className="double-column">
         <div>
           <h3>Governança</h3>
-          <ul>
+          <ul className="custom-bullets">
             <li>Diretoria aprova projetos estratégicos e orçamentos.</li>
             <li>Times de Operações, Produto, Marketing e outros executam entregas.</li>
             <li>PMO coordena, acompanha e garante aderência metodológica.</li>
@@ -21,7 +21,7 @@ export default function StructureSection() {
         </div>
         <div>
           <h3>Metodologia padrão</h3>
-          <ul>
+          <ul className="custom-bullets">
             <li>Kickoff → Planejamento → Execução → Monitoramento → Encerramento.</li>
           </ul>
           <Callout title="Instrumentos de gestão">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -402,6 +402,30 @@ button:focus-visible,
   gap: var(--spacing-xl);
 }
 
+.custom-bullets {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.custom-bullets > li {
+  position: relative;
+  padding-left: 1.8rem;
+  margin-bottom: 0.75rem;
+  line-height: 1.4;
+}
+
+.custom-bullets > li::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.4em;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background-color: var(--color-accent);
+}
+
 @media (min-width: 720px) {
   .double-column {
     grid-template-columns: repeat(2, minmax(0, 1fr));


### PR DESCRIPTION
## Summary
- add a reusable `.custom-bullets` list style to match callout bullet appearance
- apply the custom bullet styling to the governance and methodology lists in the structure section

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd8be0cc4c832ab44865af9779436d