### PR TITLE
Organize G1 artifacts navigation and add hub

### DIFF
--- a/pages/artefatos/g1/business-case.js
+++ b/pages/artefatos/g1/business-case.js
@@ -1,5 +1,6 @@
 import Layout from '../../../src/components/layout/Layout';
 import Callout from '../../../src/components/common/Callout';
+import Button from '../../../src/components/common/Button';
 
 const approvalOptions = [
   { id: 'aprovado-planejamento', label: 'Aprovado para Planejamento Detalhado (G2)' },
@@ -169,6 +170,12 @@ export default function BusinessCasePage() {
               importante é documentar o raciocínio que justifica o investimento.
             </p>
           </Callout>
+        </section>
+
+        <section className="content-card content-card--actions">
+          <Button href="/artefatos/g1" variant="secondary">
+            Voltar para Artefatos G1
+          </Button>
         </section>
       </article>
     </Layout>

--- a/pages/artefatos/g1/carta-abertura.js
+++ b/pages/artefatos/g1/carta-abertura.js
@@ -1,5 +1,6 @@
 import Layout from '../../../src/components/layout/Layout';
 import Callout from '../../../src/components/common/Callout';
+import Button from '../../../src/components/common/Button';
 
 const approvalOptions = [
   { id: 'aprovado-planejamento', label: 'Aprovado para Planejamento Detalhado (G2)' },
@@ -280,6 +281,12 @@ export default function ProjectCharterPage() {
             </p>
             <p>Deve ser anexada no repositório padrão e usada como referência em todas as reuniões de status.</p>
           </Callout>
+        </section>
+
+        <section className="content-card content-card--actions">
+          <Button href="/artefatos/g1" variant="secondary">
+            Voltar para Artefatos G1
+          </Button>
         </section>
       </article>
     </Layout>

--- a/pages/artefatos/g1/definicao-preliminar-dados.js
+++ b/pages/artefatos/g1/definicao-preliminar-dados.js
@@ -1,4 +1,5 @@
 import Layout from '../../../src/components/layout/Layout';
+import Button from '../../../src/components/common/Button';
 
 export default function PreliminaryDataDefinitionPage() {
   const hero = (
@@ -77,6 +78,12 @@ export default function PreliminaryDataDefinitionPage() {
               </ul>
             </li>
           </ul>
+        </section>
+
+        <section className="content-card content-card--actions">
+          <Button href="/artefatos/g1" variant="secondary">
+            Voltar para Artefatos G1
+          </Button>
         </section>
       </article>
     </Layout>

--- a/pages/artefatos/g1/escopo-alto-nivel.js
+++ b/pages/artefatos/g1/escopo-alto-nivel.js
@@ -1,4 +1,5 @@
 import Layout from '../../../src/components/layout/Layout';
+import Button from '../../../src/components/common/Button';
 
 export default function HighLevelScopePage() {
   const hero = (
@@ -103,6 +104,12 @@ export default function HighLevelScopePage() {
               Revisar OKRs a cada <strong>Gate</strong> → podem ser refinados conforme o projeto amadurece.
             </li>
           </ul>
+        </section>
+
+        <section className="content-card content-card--actions">
+          <Button href="/artefatos/g1" variant="secondary">
+            Voltar para Artefatos G1
+          </Button>
         </section>
       </article>
     </Layout>

--- a/pages/artefatos/g1/index.js
+++ b/pages/artefatos/g1/index.js
@@ -1,6 +1,51 @@
 import Layout from '../../../src/components/layout/Layout';
 import Button from '../../../src/components/common/Button';
 
+const g1Artifacts = [
+  {
+    title: 'Kickoff de Descoberta',
+    description:
+      'Organize o encontro inicial da fase de Descoberta garantindo alinhamento de propósito, stakeholders e expectativas antes da elaboração dos artefatos mínimos exigidos pelo Gate G1.',
+    href: '/artefatos/g1/kickoff-descoberta',
+    actionLabel: 'Acessar guia',
+  },
+  {
+    title: 'Business Case',
+    description:
+      'Consolide a justificativa estratégica e financeira para iniciativas que avançam do Gate G0 para o G1. Utilize o modelo para registrar objetivos, benefícios esperados, custos, riscos e a recomendação final do comitê.',
+    href: '/artefatos/g1/business-case',
+    actionLabel: 'Acessar modelo',
+  },
+  {
+    title: 'Carta de Abertura',
+    description:
+      'Formalize o início da iniciativa aprovando o escopo de alto nível, patrocinadores, times envolvidos e governança mínima que sustentará a fase de Descoberta.',
+    href: '/artefatos/g1/carta-abertura',
+    actionLabel: 'Acessar modelo',
+  },
+  {
+    title: 'Mapa de Stakeholders',
+    description:
+      'Identifique os públicos-chave do projeto, avalie poder e interesse de cada grupo e defina estratégias de relacionamento para garantir engajamento na fase de Descoberta.',
+    href: '/artefatos/g1/mapa-stakeholders',
+    actionLabel: 'Acessar modelo',
+  },
+  {
+    title: 'Escopo de Alto Nível',
+    description:
+      'Estabeleça a visão macro do projeto, delimitando entregas, exclusões e restrições iniciais para orientar o planejamento e o alinhamento entre as áreas impactadas.',
+    href: '/artefatos/g1/escopo-alto-nivel',
+    actionLabel: 'Acessar guia',
+  },
+  {
+    title: 'Definição Preliminar de Dados',
+    description:
+      'Antecipe quais indicadores serão acompanhados, as fontes de dados necessárias e os responsáveis por manter as informações atualizadas desde o Gate G1.',
+    href: '/artefatos/g1/definicao-preliminar-dados',
+    actionLabel: 'Acessar guia',
+  },
+];
+
 export default function ArtefatoG1Page() {
   const hero = (
     <header className="page-header-minimal">
@@ -16,51 +61,17 @@ export default function ArtefatoG1Page() {
       description="Artefatos da fase G1 do PMO Educacross."
       hero={hero}
     >
-      <section className="content-card">
-        <h2>Kickoff de Descoberta</h2>
-        <p>
-          Organize o encontro inicial da fase de Descoberta garantindo alinhamento de propósito, stakeholders e
-          expectativas antes da elaboração dos artefatos mínimos exigidos pelo Gate G1.
-        </p>
-        <Button href="/artefatos/g1/kickoff-descoberta">Acessar guia</Button>
-      </section>
-
-      <section className="content-card">
-        <h2>Business Case</h2>
-        <p>
-          Consolide a justificativa estratégica e financeira para iniciativas que avançam do Gate G0 para o G1.
-          Utilize o modelo de Business Case para registrar objetivos, benefícios esperados, custos, riscos e a
-          recomendação final do comitê.
-        </p>
-        <Button href="/artefatos/g1/business-case">Acessar modelo</Button>
-      </section>
-
-      <section className="content-card">
-        <h2>Mapa de Stakeholders</h2>
-        <p>
-          Identifique os públicos-chave do projeto, avalie poder e interesse de cada grupo e defina estratégias de
-          relacionamento para garantir engajamento na fase de Descoberta.
-        </p>
-        <Button href="/artefatos/g1/mapa-stakeholders">Acessar modelo</Button>
-      </section>
-
-      <section className="content-card">
-        <h2>Escopo de Alto Nível</h2>
-        <p>
-          Estabeleça a visão macro do projeto, delimitando entregas, exclusões e restrições iniciais para orientar o
-          planejamento e o alinhamento entre as áreas impactadas.
-        </p>
-        <Button href="/artefatos/g1/escopo-alto-nivel">Acessar guia</Button>
-      </section>
-
-      <section className="content-card">
-        <h2>Definição Preliminar de Dados</h2>
-        <p>
-          Estabeleça desde o G1 quais indicadores serão acompanhados, as fontes de dados necessárias e os
-          responsáveis por manter as informações atualizadas.
-        </p>
-        <Button href="/artefatos/g1/definicao-preliminar-dados">Acessar guia</Button>
-      </section>
+      <div className="artifact-grid">
+        {g1Artifacts.map((artifact) => (
+          <section key={artifact.href} className="content-card artifact-card">
+            <h2>{artifact.title}</h2>
+            <p>{artifact.description}</p>
+            <Button href={artifact.href} variant="secondary">
+              {artifact.actionLabel}
+            </Button>
+          </section>
+        ))}
+      </div>
     </Layout>
   );
 }

--- a/pages/artefatos/g1/kickoff-descoberta.js
+++ b/pages/artefatos/g1/kickoff-descoberta.js
@@ -1,4 +1,5 @@
 import Layout from '../../../src/components/layout/Layout';
+import Button from '../../../src/components/common/Button';
 
 export default function KickoffDescobertaPage() {
   const hero = (
@@ -100,6 +101,12 @@ export default function KickoffDescobertaPage() {
             </span>{' '}
             Em resumo: o <strong>Kickoff de Descoberta</strong> é como acender a lanterna no início da trilha — dá a direção, mostra os principais riscos e garante que todos entendam <strong>para onde estamos indo e por que</strong> antes de começar a desenhar o caminho detalhado.
           </p>
+        </section>
+
+        <section className="content-card content-card--actions">
+          <Button href="/artefatos/g1" variant="secondary">
+            Voltar para Artefatos G1
+          </Button>
         </section>
       </article>
     </Layout>

--- a/pages/artefatos/g1/mapa-stakeholders.js
+++ b/pages/artefatos/g1/mapa-stakeholders.js
@@ -1,5 +1,6 @@
 import Layout from '../../../src/components/layout/Layout';
 import Callout from '../../../src/components/common/Callout';
+import Button from '../../../src/components/common/Button';
 
 export default function StakeholderMapPage() {
   const hero = (
@@ -178,6 +179,12 @@ export default function StakeholderMapPage() {
               </li>
             </ul>
           </Callout>
+        </section>
+
+        <section className="content-card content-card--actions">
+          <Button href="/artefatos/g1" variant="secondary">
+            Voltar para Artefatos G1
+          </Button>
         </section>
       </article>
     </Layout>

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -10,10 +10,24 @@ const phaseLinks = [
   { href: '/fases/g4', label: 'G4' },
 ];
 
-const artefatoLinks = phaseLinks.map((phase) => ({
-  href: `/artefatos/${phase.label.toLowerCase()}`,
-  label: phase.label,
-}));
+const artefatoLinks = [
+  { href: '/artefatos/g0', label: 'G0' },
+  {
+    href: '/artefatos/g1',
+    label: 'G1',
+    children: [
+      { href: '/artefatos/g1/business-case', label: 'Business Case' },
+      { href: '/artefatos/g1/carta-abertura', label: 'Carta de Abertura' },
+      { href: '/artefatos/g1/definicao-preliminar-dados', label: 'Definição Preliminar de Dados' },
+      { href: '/artefatos/g1/escopo-alto-nivel', label: 'Escopo de Alto Nível' },
+      { href: '/artefatos/g1/kickoff-descoberta', label: 'Kickoff de Descoberta' },
+      { href: '/artefatos/g1/mapa-stakeholders', label: 'Mapa de Stakeholders' },
+    ],
+  },
+  { href: '/artefatos/g2', label: 'G2' },
+  { href: '/artefatos/g3', label: 'G3' },
+  { href: '/artefatos/g4', label: 'G4' },
+];
 
 const menuItems = [
   { label: 'Home', href: '/' },
@@ -44,11 +58,23 @@ export default function Header() {
     return basePath === href;
   };
 
+  const hasActiveNestedLink = (link) => {
+    if (link.href && isActive(link.href)) {
+      return true;
+    }
+
+    if (Array.isArray(link.children) && link.children.length > 0) {
+      return link.children.some((childLink) => hasActiveNestedLink(childLink));
+    }
+
+    return false;
+  };
+
   const itemsWithActiveState = useMemo(
     () =>
       menuItems.map((item) => ({
         ...item,
-        isActive: item.href ? isActive(item.href) : item.children?.some((child) => isActive(child.href)),
+        isActive: item.href ? isActive(item.href) : item.children?.some((child) => hasActiveNestedLink(child)),
       })),
     [basePath]
   );
@@ -134,13 +160,52 @@ export default function Header() {
                     </button>
                     <ul id={submenuId} className="site-nav__submenu">
                       {item.children.map((child) => {
-                        const active = isActive(child.href);
+                        const childHasChildren = Array.isArray(child.children) && child.children.length > 0;
+                        const childIsActive = childHasChildren
+                          ? child.children.some((grandchild) => isActive(grandchild.href)) || (child.href ? isActive(child.href) : false)
+                          : isActive(child.href);
+
+                        if (childHasChildren) {
+                          return (
+                            <li
+                              key={child.label}
+                              className={`site-nav__submenu-item has-nested${childIsActive ? ' is-active' : ''}`}
+                            >
+                              <Link
+                                href={child.href}
+                                className={`site-nav__submenu-link${childIsActive ? ' is-active' : ''}`}
+                                aria-current={childIsActive && child.href ? 'page' : undefined}
+                                onClick={handleLinkClick}
+                              >
+                                {child.label}
+                              </Link>
+                              <ul className="site-nav__subsubmenu">
+                                {child.children.map((grandchild) => {
+                                  const grandchildActive = isActive(grandchild.href);
+                                  return (
+                                    <li key={grandchild.href} className="site-nav__subsubmenu-item">
+                                      <Link
+                                        href={grandchild.href}
+                                        className={`site-nav__subsubmenu-link${grandchildActive ? ' is-active' : ''}`}
+                                        aria-current={grandchildActive ? 'page' : undefined}
+                                        onClick={handleLinkClick}
+                                      >
+                                        {grandchild.label}
+                                      </Link>
+                                    </li>
+                                  );
+                                })}
+                              </ul>
+                            </li>
+                          );
+                        }
+
                         return (
                           <li key={child.href} className="site-nav__submenu-item">
                             <Link
                               href={child.href}
-                              className={`site-nav__submenu-link${active ? ' is-active' : ''}`}
-                              aria-current={active ? 'page' : undefined}
+                              className={`site-nav__submenu-link${childIsActive ? ' is-active' : ''}`}
+                              aria-current={childIsActive ? 'page' : undefined}
                               onClick={handleLinkClick}
                             >
                               {child.label}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -213,6 +213,12 @@ button:focus-visible,
   border: 1px solid var(--color-border);
 }
 
+.content-card--actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
 .content-card h2 {
   font-size: var(--font-size-heading-md);
   margin-bottom: var(--spacing-card-gap);
@@ -297,6 +303,39 @@ button:focus-visible,
   display: flex;
   flex-direction: column;
   gap: var(--spacing-2xl-plus);
+}
+
+.artifact-grid {
+  display: grid;
+  gap: var(--spacing-2xl-plus);
+}
+
+.artifact-grid .content-card {
+  margin-bottom: 0;
+}
+
+@media (min-width: 768px) {
+  .artifact-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1200px) {
+  .artifact-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.artifact-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-card-gap);
+  height: 100%;
+}
+
+.artifact-card .btn {
+  margin-top: auto;
+  align-self: flex-start;
 }
 
 .form-grid {
@@ -1634,6 +1673,12 @@ footer span {
   margin-top: var(--space-12);
 }
 
+.site-nav__submenu-item.has-nested {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}
+
 .site-nav__submenu-link {
   display: flex;
   width: 100%;
@@ -1656,6 +1701,41 @@ footer span {
 }
 
 .site-nav__submenu-link.is-active {
+  background: rgba(var(--color-accent-rgb), 0.22);
+  color: var(--color-accent-light);
+}
+
+.site-nav__subsubmenu {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0 var(--space-16);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+.site-nav__subsubmenu-item {
+  margin: 0;
+}
+
+.site-nav__subsubmenu-link {
+  display: block;
+  padding: var(--space-6) var(--space-10);
+  color: rgba(255, 255, 255, 0.92);
+  font-size: var(--font-size-sm-strong);
+  text-decoration: none;
+  border-radius: var(--radius-sm);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.site-nav__subsubmenu-link:hover,
+.site-nav__subsubmenu-link:focus-visible {
+  outline: none;
+  background: rgba(var(--color-accent-rgb), 0.18);
+  color: var(--color-accent-light);
+}
+
+.site-nav__subsubmenu-link.is-active {
   background: rgba(var(--color-accent-rgb), 0.22);
   color: var(--color-accent-light);
 }
@@ -1951,6 +2031,10 @@ footer span {
     gap: var(--space-10);
   }
 
+  .site-nav__submenu-item.has-nested {
+    gap: var(--space-8);
+  }
+
   .site-nav__item.has-submenu.is-open > .site-nav__submenu {
     display: flex;
     flex-direction: column;
@@ -1964,6 +2048,22 @@ footer span {
     padding: var(--space-10) var(--space-12);
     font-size: var(--font-size-sm-strong);
     color: var(--color-text);
+  }
+
+  .site-nav__subsubmenu {
+    padding-left: var(--space-12);
+  }
+
+  .site-nav__subsubmenu-link {
+    padding: var(--space-8) var(--space-10);
+    color: var(--color-text);
+  }
+
+  .site-nav__subsubmenu-link:hover,
+  .site-nav__subsubmenu-link:focus-visible,
+  .site-nav__subsubmenu-link.is-active {
+    background: rgba(var(--color-primary-rgb), 0.12);
+    color: var(--color-primary);
   }
 
   .site-nav__submenu-link:hover,


### PR DESCRIPTION
## Summary
- nest the G1 discovery artifacts under Artefatos in the main navigation with updated submenu handling and styling
- turn /artefatos/g1 into a card hub that explains each G1 document and links to the detailed pages
- add a "Voltar para Artefatos G1" action to every G1 artifact and supporting styles for consistent layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ded71ad9fc832abd68a2714a63b1ea