### PR TITLE
Remove Plano Jurídico card from specific G2 artifact pages

### DIFF
--- a/pages/artefatos/g2/orcamento-baseline.js
+++ b/pages/artefatos/g2/orcamento-baseline.js
@@ -18,15 +18,6 @@ export default function OrcamentoBaselinePage() {
     >
       <article className="artifact-form">
         <section className="content-card">
-          <h2>O que é o Plano Jurídico &amp; Contratos</h2>
-          <p>
-            É o documento que organiza <strong>todas as obrigações legais, contratuais e regulatórias</strong> do
-            projeto, definindo responsabilidades, prazos, cláusulas críticas e formas de mitigação de riscos
-            jurídicos.
-          </p>
-        </section>
-
-        <section className="content-card">
           <h2>G2: Orçamento Base</h2>
           <h3>Orçamento Baseline – Educacross</h3>
           <p>

--- a/pages/artefatos/g2/plano-pedagogico-produto.js
+++ b/pages/artefatos/g2/plano-pedagogico-produto.js
@@ -18,14 +18,6 @@ export default function PlanoPedagogicoProdutoPage() {
     >
       <article className="artifact-form">
         <section className="content-card">
-          <h2>O que é o Plano Jurídico &amp; Contratos</h2>
-          <p>
-            É o documento que organiza <strong>todas as obrigações legais, contratuais e regulatórias</strong> do projeto,
-            definindo responsabilidades, prazos, cláusulas críticas e formas de mitigação de riscos jurídicos.
-          </p>
-        </section>
-
-        <section className="content-card">
           <h2>O que é o Plano Pedagógico &amp; Produto</h2>
           <p>É o documento que define:</p>
           <ul>

--- a/pages/artefatos/g2/plano-qualidade-criterios-aceite.js
+++ b/pages/artefatos/g2/plano-qualidade-criterios-aceite.js
@@ -18,15 +18,6 @@ export default function PlanoQualidadeCriteriosAceitePage() {
     >
       <article className="artifact-form">
         <section className="content-card">
-          <h2>O que é o Plano Jurídico &amp; Contratos</h2>
-          <p>
-            É o documento que organiza <strong>todas as obrigações legais, contratuais e regulatórias</strong> do
-            projeto, definindo responsabilidades, prazos, cláusulas críticas e formas de mitigação de riscos
-            jurídicos.
-          </p>
-        </section>
-
-        <section className="content-card">
           <h2>O que é <strong>Qualidade &amp; Critérios de Aceite</strong></h2>
           <ul>
             <li>

--- a/pages/artefatos/g2/plano-treinamento-change-management.js
+++ b/pages/artefatos/g2/plano-treinamento-change-management.js
@@ -18,14 +18,6 @@ export default function PlanoTreinamentoChangeManagementPage() {
     >
       <article className="artifact-form">
         <section className="content-card">
-          <h2>O que é o Plano Jurídico &amp; Contratos</h2>
-          <p>
-            É o documento que organiza <strong>todas as obrigações legais, contratuais e regulatórias</strong> do projeto,
-            definindo responsabilidades, prazos, cláusulas críticas e formas de mitigação de riscos jurídicos.
-          </p>
-        </section>
-
-        <section className="content-card">
           <h2>O que é</h2>
           <ul>
             <li>


### PR DESCRIPTION
## Summary
- remove the Plano Jurídico & Contratos content card from the four specified G2 artifact pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3d5d47bb0832a90cafc5343a353e7