### PR TITLE
Adjust G3 committee page route and content

### DIFF
--- a/pages/artefatos/g3/comite-de-projeto.js
+++ b/pages/artefatos/g3/comite-de-projeto.js
@@ -1,7 +1,7 @@
 import Layout from '../../../src/components/layout/Layout';
 import Callout from '../../../src/components/common/Callout';
 
-export default function PlanoJuridicoContratosG3Page() {
+export default function ComiteDeProjetoG3Page() {
   const hero = (
     <header className="page-header-minimal">
       <div className="page-header-minimal__inner">
@@ -12,18 +12,11 @@ export default function PlanoJuridicoContratosG3Page() {
 
   return (
     <Layout
-      title="Plano Jurídico & Contratos G3 - PMO Educacross"
+      title="Comitê de Projeto G3 - PMO Educacross"
       description="Template do comitê de projeto quinzenal com foco em governança jurídica e contratual para o Gate G3."
       hero={hero}
     >
       <article className="artifact-form">
-        <section className="content-card">
-          <h2>O que é o Plano Jurídico &amp; Contratos</h2>
-          <p>
-            É o documento que organiza <strong>todas as obrigações legais, contratuais e regulatórias</strong> do projeto,
-            definindo responsabilidades, prazos, cláusulas críticas e formas de mitigação de riscos jurídicos.
-          </p>
-        </section>
 
         <section className="content-card">
           <h2>Dados do Comitê</h2>

--- a/pages/artefatos/g3/index.js
+++ b/pages/artefatos/g3/index.js
@@ -20,7 +20,7 @@ const g3Artifacts = [
     title: 'Comitê de Projeto (quinzenal)',
     description:
       'Template completo do comitê quinzenal com foco em decisões jurídicas, pendências contratuais e governança executiva do Gate G3.',
-    href: '/artefatos/g3/plano-juridico-contratos',
+    href: '/artefatos/g3/comite-de-projeto',
     actionLabel: 'Acessar guia',
   },
 ];


### PR DESCRIPTION
## Summary
- rename the G3 Plano Jurídico & Contratos page to `/artefatos/g3/comite-de-projeto`
- remove the introductory Plano Jurídico content-card from the committee template
- point the G3 artifact listing to the new route and update the page title

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3d80682b0832a89fb2999029fb4f0