### PR TITLE
Fix Next.js build issues for Vercel deployment

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   trailingSlash: true,
-  experimental: {
-    optimizePackageImports: ['react', 'react-dom'],
-  },
 };
 
 module.exports = nextConfig;

--- a/pages/fluxo-pmo/index.js
+++ b/pages/fluxo-pmo/index.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import Script from 'next/script';
 import FlowHero from '@/app/(public)/fluxo-pmo/_components/FlowHero';
 import FlowQuickNav from '@/app/(public)/fluxo-pmo/_components/FlowQuickNav';
 import FlowSection from '@/app/(public)/fluxo-pmo/_components/FlowSection';
@@ -7,122 +7,129 @@ import flowSections from '@/app/(public)/fluxo-pmo/_data/sections';
 import Layout from '@/components/layout/SiteLayout';
 
 const navSections = flowSections.map(({ id, label }) => ({ id, label }));
+const flowScript = `
+(function () {
+  if (typeof window === 'undefined') {
+    return;
+  }
 
-export default function FluxoPMO() {
-  const navContainerRef = useRef(null);
+  var body = document.body;
+  if (!body) {
+    return;
+  }
 
-  useEffect(() => {
-    document.body.classList.add('flow-body');
-    return () => {
-      document.body.classList.remove('flow-body');
-    };
-  }, []);
+  var addBodyClass = function () {
+    body.classList.add('flow-body');
+  };
 
-  useEffect(() => {
-    const navContainer = navContainerRef.current;
-    if (!navContainer) {
-      return undefined;
+  var removeBodyClass = function () {
+    body.classList.remove('flow-body');
+  };
+
+  addBodyClass();
+  window.addEventListener('pageshow', addBodyClass);
+  window.addEventListener('pagehide', removeBodyClass);
+  window.addEventListener('beforeunload', removeBodyClass);
+
+  var navContainer = document.querySelector('.flow-main-layout');
+  if (!navContainer) {
+    return;
+  }
+
+  var navLinks = Array.prototype.slice.call(navContainer.querySelectorAll('a[data-section]'));
+  if (!navLinks.length) {
+    return;
+  }
+
+  var sections = Array.from(new Set(navLinks.map(function (link) {
+    var sectionId = link.dataset.section || (link.getAttribute('href') || '').replace('#', '');
+    var sectionEl = sectionId ? document.getElementById(sectionId) : null;
+
+    if (sectionEl) {
+      link.dataset.section = sectionId;
     }
 
-    const navLinks = Array.from(navContainer.querySelectorAll('a[data-section]'));
-    if (!navLinks.length) {
-      return undefined;
-    }
+    return sectionEl;
+  }).filter(Boolean)));
 
-    const sections = Array.from(
-      new Set(
-        navLinks
-          .map((link) => {
-            const sectionId = link.dataset.section || link.getAttribute('href')?.replace('#', '');
-            const sectionEl = sectionId ? document.getElementById(sectionId) : null;
-            if (sectionEl) {
-              link.dataset.section = sectionId;
-            }
-            return sectionEl;
-          })
-          .filter(Boolean)
-      )
-    );
+  if (!sections.length) {
+    return;
+  }
 
-    if (!sections.length) {
-      return undefined;
-    }
+  var setActiveLink = function (sectionId) {
+    navLinks.forEach(function (link) {
+      var isActive = link.dataset.section === sectionId;
+      link.classList.toggle('active', isActive);
 
-    const setActiveLink = (sectionId) => {
-      navLinks.forEach((link) => {
-        const isActive = link.dataset.section === sectionId;
-        link.classList.toggle('active', isActive);
-        if (isActive) {
-          link.setAttribute('aria-current', 'true');
-        } else {
-          link.removeAttribute('aria-current');
-        }
-      });
-    };
-
-    const observerOptions = {
-      root: null,
-      rootMargin: '-35% 0px -45% 0px',
-      threshold: [0.25, 0.5, 0.75],
-    };
-
-    const observer = new IntersectionObserver((entries) => {
-      const visibleSections = entries
-        .filter((entry) => entry.isIntersecting)
-        .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
-
-      if (visibleSections.length > 0) {
-        setActiveLink(visibleSections[0].target.id);
-        return;
+      if (isActive) {
+        link.setAttribute('aria-current', 'true');
+      } else {
+        link.removeAttribute('aria-current');
       }
+    });
+  };
 
-      const aboveViewport = entries
-        .filter((entry) => entry.boundingClientRect.top < 0)
-        .sort((a, b) => b.boundingClientRect.top - a.boundingClientRect.top);
-
-      if (aboveViewport.length > 0) {
-        setActiveLink(aboveViewport[0].target.id);
-      }
-    }, observerOptions);
-
-    sections.forEach((section) => observer.observe(section));
-
-    const initialId = window.location.hash ? window.location.hash.substring(1) : sections[0].id;
-    if (initialId) {
-      setActiveLink(initialId);
-    }
-
-    const handleClick = (event) => {
-      const sectionId = event.currentTarget.dataset.section;
-      if (sectionId) {
-        setActiveLink(sectionId);
-      }
-    };
-
-    navLinks.forEach((link) => {
-      link.addEventListener('click', handleClick);
+  var observerOptions = { root: null, rootMargin: '-35% 0px -45% 0px', threshold: [0.25, 0.5, 0.75] };
+  var observer = new IntersectionObserver(function (entries) {
+    var visibleSections = entries.filter(function (entry) { return entry.isIntersecting; }).sort(function (a, b) {
+      return b.intersectionRatio - a.intersectionRatio;
     });
 
-    return () => {
-      observer.disconnect();
-      navLinks.forEach((link) => {
-        link.removeEventListener('click', handleClick);
-        link.classList.remove('active');
-        link.removeAttribute('aria-current');
-      });
-    };
-  }, []);
+    if (visibleSections.length > 0) {
+      setActiveLink(visibleSections[0].target.id);
+      return;
+    }
 
-  const sectionsToRender = useMemo(
-    () =>
-      flowSections.map((section) => (
-        <FlowSection key={section.id} id={section.id} badge={section.badge} title={section.title}>
-          {section.content}
-        </FlowSection>
-      )),
-    []
-  );
+    var aboveViewport = entries.filter(function (entry) {
+      return entry.boundingClientRect.top < 0;
+    }).sort(function (a, b) {
+      return b.boundingClientRect.top - a.boundingClientRect.top;
+    });
 
+    if (aboveViewport.length > 0) {
+      setActiveLink(aboveViewport[0].target.id);
+    }
+  }, observerOptions);
+
+  sections.forEach(function (section) {
+    observer.observe(section);
+  });
+
+  var initialId = window.location.hash ? window.location.hash.substring(1) : sections[0].id;
+  if (initialId) {
+    setActiveLink(initialId);
+  }
+
+  var handleClick = function (event) {
+    var sectionId = event.currentTarget.dataset.section;
+    if (sectionId) {
+      setActiveLink(sectionId);
+    }
+  };
+
+  navLinks.forEach(function (link) {
+    link.addEventListener('click', handleClick);
+  });
+
+  var cleanup = function () {
+    observer.disconnect();
+    navLinks.forEach(function (link) {
+      link.removeEventListener('click', handleClick);
+      link.classList.remove('active');
+      link.removeAttribute('aria-current');
+    });
+    removeBodyClass();
+    window.removeEventListener('pageshow', addBodyClass);
+    window.removeEventListener('pagehide', removeBodyClass);
+    window.removeEventListener('beforeunload', removeBodyClass);
+    window.removeEventListener('pagehide', cleanup);
+  };
+
+  window.addEventListener('pagehide', cleanup);
+})();
+`;
+
+export default function FluxoPMO() {
   return (
     <Layout
       title="Fluxo do PMO Educacross"
@@ -130,11 +137,20 @@ export default function FluxoPMO() {
       hero={<FlowHero />}
       mainClassName="flow-page"
     >
-      <div className="flow-main-layout" ref={navContainerRef}>
+      <Script id="flow-navigation-script" strategy="lazyOnload">
+        {flowScript}
+      </Script>
+      <div className="flow-main-layout">
         <FlowSideNav sections={navSections} />
         <div className="flow-main-content">
           <FlowQuickNav sections={navSections} />
-          <main className="flow-content">{sectionsToRender}</main>
+          <main className="flow-content">
+            {flowSections.map((section) => (
+              <FlowSection key={section.id} id={section.id} badge={section.badge} title={section.title}>
+                {section.content}
+              </FlowSection>
+            ))}
+          </main>
         </div>
       </div>
     </Layout>

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -11,6 +11,14 @@ const run = (command) => {
 
 run('next build');
 
+const hasAppDirectory = fs.existsSync('app') || fs.existsSync(path.join('src', 'app'));
+const shouldSkipExport = hasAppDirectory || process.env.SKIP_NEXT_EXPORT === 'true';
+
+if (shouldSkipExport) {
+  console.log('\nSkipping `next export` because the App Router is enabled or export was explicitly disabled.');
+  process.exit(0);
+}
+
 console.log('\nRunning `next export` to generate the static output directory.');
 run('next export');
 

--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -1,8 +1,4 @@
 import './globals.css';
-import { DM_Sans, Poppins } from 'next/font/google';
-
-const dmSans = DM_Sans({ subsets: ['latin'], variable: '--font-dm-sans', weight: ['400', '500', '700'] });
-const poppins = Poppins({ subsets: ['latin'], variable: '--font-poppins', weight: ['300', '400', '500', '600', '700'] });
 
 /** @type {import('next').Metadata} */
 export const metadata = {
@@ -23,7 +19,7 @@ export const metadata = {
  */
 export default function RootLayout({ children }) {
   return (
-    <html lang="pt-BR" className={`${dmSans.variable} ${poppins.variable}`}>
+    <html lang="pt-BR">
       <body>{children}</body>
     </html>
   );

--- a/src/components/layout/SiteLayout.jsx
+++ b/src/components/layout/SiteLayout.jsx
@@ -1,6 +1,8 @@
+import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import SiteFooter from './SiteFooter';
-import SiteHeader from './SiteHeader';
+
+const SiteHeader = dynamic(() => import('./SiteHeader'), { ssr: false });
 
 /**
  * Shell responsável por estruturar páginas renderizadas via Pages Router.


### PR DESCRIPTION
## Summary
- add jsconfig path mapping so `@/` imports resolve during builds
- remove Next Font usage and load the SiteHeader dynamically to avoid SSR hook errors
- rewrite the Fluxo PMO page to use a client script for navigation behavior and skip `next export` when the App Router is present

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e413e16e54832a868e32f5d0808713