### PR TITLE
Fix Vercel build output directory configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,4 @@
 {
-  "buildCommand": "npm run build"
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next"
 }


### PR DESCRIPTION
## Summary
- configure Vercel to upload the Next.js build output from the .next folder

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e422eb67d4832aa80d8b445e6e3893