### PR TITLE
Fix Vercel deployment by relying on default output directory

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,3 @@
 {
-  "buildCommand": "npm run build",
-  "outputDirectory": ".next"
+  "buildCommand": "npm run build"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "buildCommand": "npm run build"
+  "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary
- remove the custom outputDirectory from the Vercel configuration so the Next.js runtime can handle routing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4f880a8c8832a8ca286b56922b3e0