### PR TITLE
Fix Vercel build by restoring Next.js output handling

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "buildCommand": "npm run build"
+  "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary
- ensure the Vercel configuration relies on the default Next.js framework handling so the build produces the expected output directory

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4fa1d3768832a9f93692e926421dc