### PR TITLE
Adjust spacing below header to prevent overlap

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -242,14 +242,14 @@ button:focus-visible,
 .page-main {
   max-width: var(--layout-container);
   margin: calc(-1 * var(--spacing-8xl)) auto var(--spacing-section);
-  padding: 0 var(--spacing-gutter) var(--spacing-section);
+  padding: calc(var(--header-height) + var(--spacing-lg-plus)) var(--spacing-gutter) var(--spacing-section);
   position: relative;
 }
 
 .page-main.flow-page {
   max-width: none;
   margin: 0;
-  padding: 0;
+  padding: calc(var(--header-height) + var(--spacing-lg-plus)) 0 0;
 }
 
 .content-card {


### PR DESCRIPTION
## Summary
- add vertical padding to the main content area so that it clears the sticky header height
- ensure flow-page layouts also include the same top offset to keep body sections visible under the header

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e5074411dc832a887f00898c5a9d66