### PR TITLE
Fix SiteHeader hydration mismatch in SiteLayout

### DIFF
--- a/src/components/layout/SiteLayout.jsx
+++ b/src/components/layout/SiteLayout.jsx
@@ -1,8 +1,6 @@
-import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import SiteFooter from './SiteFooter';
-
-const SiteHeader = dynamic(() => import('./SiteHeader'), { ssr: false });
+import SiteHeader from './SiteHeader';
 
 /**
  * Shell responsável por estruturar páginas renderizadas via Pages Router.


### PR DESCRIPTION
## Summary
- render the shared SiteHeader during SSR within the pages router layout to eliminate hydration mismatches

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e50f7886b8832a8bc0f91c59c23c49