### PR TITLE
Fix SiteLayout header hydration mismatch

### DIFF
--- a/src/components/layout/SiteLayout.jsx
+++ b/src/components/layout/SiteLayout.jsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import { useEffect, useState } from 'react';
 import SiteFooter from './SiteFooter';
 import SiteHeader from './SiteHeader';
 
@@ -24,12 +23,6 @@ export default function SiteLayout({
   title,
 }) {
   const mainClass = ['page-main', mainClassName].filter(Boolean).join(' ');
-  const [isClientReady, setIsClientReady] = useState(false);
-
-  useEffect(() => {
-    setIsClientReady(true);
-  }, []);
-
   return (
     <>
       <Head>
@@ -41,7 +34,7 @@ export default function SiteLayout({
         <a href="#conteudo-principal" className="skip-to-content">
           Ir para o conteúdo principal
         </a>
-        {isClientReady ? <SiteHeader /> : null}
+        <SiteHeader />
         {hero}
         <main id="conteudo-principal" className={mainClass}>
           {children}


### PR DESCRIPTION
## Summary
- render the global SiteHeader during the initial server render to avoid hydration mismatches
- remove the client-ready guard from the SiteLayout shell now that the header is safe to render on the server

## Testing
- npm run lint *(fails: ESLint must be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e515471f98832aa3f3acc07b70466d