### PR TITLE
Fix hydration error when resolving active nav state

### DIFF
--- a/src/components/layout/SiteHeader.jsx
+++ b/src/components/layout/SiteHeader.jsx
@@ -1,27 +1,14 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 import { useEffect, useId, useMemo, useState } from 'react';
 import { mainNavigation } from '@/lib/navigation';
+import useSafePathname from '@/hooks/useSafePathname';
 
 const getBasePath = (path) => path.split('#')[0] || '/';
 
 export default function SiteHeader() {
-  let pathname = null;
-
-  if (typeof usePathname === 'function') {
-    try {
-      pathname = usePathname();
-    } catch (error) {
-      // `usePathname` is only supported in the App Router. When this header is rendered
-      // inside the legacy Pages Router we fall back to location-based detection.
-      if (process.env.NODE_ENV !== 'production') {
-        // eslint-disable-next-line no-console
-        console.warn('SiteHeader: falling back to window.location for active link detection.', error);
-      }
-    }
-  }
+  const pathname = useSafePathname();
   const [resolvedPath, setResolvedPath] = useState(() => getBasePath(pathname ?? '/'));
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [openSubmenu, setOpenSubmenu] = useState(null);

--- a/src/hooks/useSafePathname.js
+++ b/src/hooks/useSafePathname.js
@@ -1,0 +1,38 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useRef } from 'react';
+
+/**
+ * Attempts to read the current pathname using Next.js App Router's {@link usePathname}.
+ * When rendered inside the legacy Pages Router the hook throws an error because the
+ * navigation context is not available. We catch that exception and fall back to
+ * returning `null`, allowing consumers to handle client-side detection (for example
+ * through `window.location`).
+ *
+ * A development-only warning is logged the first time the fallback is triggered to
+ * help surface unexpected usages while avoiding hydration issues caused by
+ * conditionally calling hooks.
+ *
+ * @returns {string | null}
+ */
+export function useSafePathname() {
+  const hasWarnedRef = useRef(false);
+
+  try {
+    return usePathname();
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production' && !hasWarnedRef.current) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'useSafePathname: falling back to window.location because usePathname is unavailable.',
+        error
+      );
+      hasWarnedRef.current = true;
+    }
+
+    return null;
+  }
+}
+
+export default useSafePathname;


### PR DESCRIPTION
## Summary
- replace the conditional `usePathname` usage in `SiteHeader` with a safe wrapper hook to keep hook ordering consistent during hydration
- add a reusable `useSafePathname` hook to gracefully fall back to `window.location` when rendered in the legacy Pages Router

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5156be824832ab2342fa34627acfe