### PR TITLE
fix: update next integrity hash in lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -260,7 +260,7 @@
     "node_modules/next": {
       "version": "14.2.3",
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.3.tgz",
-      "integrity": "sha512-Y2wTcTbO4WwEsVb4A8VSnOsG1I9ok+h74q0ZdxkwM3EODqrs4pasq7O0iUxbcS9VtWMicG7f3+HAj0r1+NtKSw==",
+      "integrity": "sha512-dowFkFTR8v79NPJO4QsBUtxv0g9BrS/phluVpMAt2ku7H+cbcBJlopXjkWlwxrk/xGqMemr7JkGPGemPrLLX7A==",
       "license": "MIT",
       "dependencies": {
         "@next/env": "14.2.3",


### PR DESCRIPTION
## Summary
- update the Next.js tarball integrity in the lockfile so npm installs succeed on Vercel

## Testing
- not run (npm registry access is blocked in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e55f87ba90832a897a9fbfd2a3b076