### PR TITLE
Fix npm integrity mismatch for @next/env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
     "node_modules/@next/env": {
       "version": "14.2.3",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.3.tgz",
-      "integrity": "sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw==",
+      "integrity": "sha512-W7fd7IbkfmeeY2gXrzJYDx8D2lWKbVoTIj1o1ScPHNzvp30s1AuoEFSdr39bC5sjxJaxTtq3OTCZboNp0lNWHA==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {


### PR DESCRIPTION
## Summary
- update the lockfile entry for @next/env so the integrity hash matches the tarball served by the registry
- unblock `npm install` during Vercel builds that were failing with EINTEGRITY

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5611a0ccc832a9bec89dd6a36835e