### PR TITLE
Ensure favicon loads on pages router routes

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import logoBelinha from '@/img/Logo_Belinha.png';
 import '@/app/globals.css';
 
 export default function App({ Component, pageProps }) {
@@ -8,6 +9,7 @@ export default function App({ Component, pageProps }) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link rel="icon" href={logoBelinha.src} type="image/png" />
         <link
           href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=DM+Sans:wght@400;500;700&display=swap"
           rel="stylesheet"


### PR DESCRIPTION
## Summary
- import the shared logo asset in the pages router `_app` and expose it as the global favicon so it appears on every route

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e563938828832aacb8985340a855e4