### PR TITLE
Match page hero spacing with flow hero layout

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -134,7 +134,7 @@ button:focus-visible,
 .page-hero {
   background: var(--gradient-hero);
   color: var(--color-white);
-  padding: var(--spacing-6xl) 0 var(--spacing-section-lg);
+  padding: var(--spacing-7xl-plus) 0 var(--spacing-section-max);
   position: relative;
   overflow: hidden;
 }
@@ -149,15 +149,15 @@ button:focus-visible,
 }
 
 .page-hero::before {
-  width: 420px;
-  height: 420px;
+  width: 520px;
+  height: 520px;
   top: calc(-1 * var(--spacing-section-max));
   right: calc(-1 * var(--spacing-section-xl));
 }
 
 .page-hero::after {
-  width: 320px;
-  height: 320px;
+  width: 360px;
+  height: 360px;
   bottom: calc(-1 * var(--spacing-section-hero));
   left: calc(-1 * var(--spacing-section-snug));
 }


### PR DESCRIPTION
## Summary
- align the page hero padding and decorative element sizes with the flow hero styling for consistent layout spacing

## Testing
- npm run lint *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e565952114832a92978bd962e6ebdb