### PR TITLE
Fix hero section full width layout

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -137,6 +137,8 @@ button:focus-visible,
   padding: var(--spacing-7xl-plus) 0 var(--spacing-section-max);
   position: relative;
   overflow: hidden;
+  width: 100vw;
+  margin-inline: calc(50% - 50vw);
 }
 
 .page-hero::before,


### PR DESCRIPTION
## Summary
- extend the page hero section to span the full viewport width by offsetting its margins

## Testing
- npm install *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e5669ac514832a916c711c5f3d6c33