### PR TITLE
Adjust home hero spacing under header

### DIFF
--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -11,7 +11,7 @@ export default function RootPage() {
         Ir para o conteúdo principal
       </a>
       <SiteHeader />
-      <main id="conteudo-principal" className="page-main">
+      <main id="conteudo-principal" className="page-main page-main--with-hero">
         <HomeContent />
       </main>
       <SiteFooter />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -248,6 +248,10 @@ button:focus-visible,
   position: relative;
 }
 
+.page-main.page-main--with-hero {
+  padding-top: var(--header-height);
+}
+
 .page-main.flow-page {
   max-width: none;
   margin: 0;


### PR DESCRIPTION
## Summary
- add a specific modifier class to the home page main element when rendering the hero
- reduce the top padding applied in that scenario so the hero sits flush with the sticky header

## Testing
- npm install *(fails in CI sandbox: 403 Forbidden while fetching next@14.2.3)*

------
https://chatgpt.com/codex/tasks/task_e_68e568481f74832ab6c3653f0f772897