### PR TITLE
Atualiza header com foto da Belinha e ajusta hero

### DIFF
--- a/src/components/layout/SiteHeader.jsx
+++ b/src/components/layout/SiteHeader.jsx
@@ -1,9 +1,11 @@
 'use client';
 
+import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useId, useMemo, useState } from 'react';
 import { mainNavigation } from '@/lib/navigation';
 import useSafePathname from '@/hooks/useSafePathname';
+import LogoBelinha from '@/img/Logo_Belinha.png';
 
 const getBasePath = (path) => path.split('#')[0] || '/';
 
@@ -102,8 +104,16 @@ export default function SiteHeader() {
             aria-label="PMO Educacross - Página inicial"
             onClick={() => handleLinkClick('/')}
           >
-            <span className="brand-mark" aria-hidden="true">
-              EC
+            <span className="brand-mark">
+              <Image
+                src={LogoBelinha}
+                alt="Belinha"
+                className="brand-mark__image"
+                width={LogoBelinha.width}
+                height={LogoBelinha.height}
+                sizes="44px"
+                priority
+              />
             </span>
             <span className="brand-text">PMO Educacross</span>
           </Link>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -246,10 +246,11 @@ button:focus-visible,
   margin: calc(-1 * var(--spacing-8xl)) auto var(--spacing-section);
   padding: calc(var(--header-height) + var(--spacing-lg-plus)) var(--spacing-gutter) var(--spacing-section);
   position: relative;
+  scroll-margin-top: var(--header-height);
 }
 
 .page-main.page-main--with-hero {
-  padding-top: var(--header-height);
+  padding-top: 0;
 }
 
 .page-main.flow-page {
@@ -1615,6 +1616,14 @@ footer span {
   letter-spacing: 0.08em;
   color: var(--color-accent-light);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.18);
+  overflow: hidden;
+}
+
+.brand-mark__image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: inherit;
 }
 
 .brand-text {


### PR DESCRIPTION
## Summary
- adiciona a imagem Logo_Belinha ao cabeçalho como foto de perfil com carregamento prioritário
- atualiza o estilo do cabeçalho para suportar a nova imagem mantendo a forma circular
- remove o espaçamento entre o cabeçalho e o hero inicial e adiciona scroll-margin para manter a âncora acessível

## Testing
- npm run lint *(falhou: dependências Next.js indisponíveis no registro npm desta sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e57594b8c4832aa6f1c2981744b526