### PR TITLE
Add top margin to hero highlight section

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -212,6 +212,7 @@ button:focus-visible,
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-sm-plus);
+  margin-top: var(--spacing-3xl);
   background: var(--color-white-ghost);
   border-radius: var(--radius-xs);
   padding: var(--spacing-md) var(--spacing-card-gap);


### PR DESCRIPTION
## Summary
- add top margin to the hero highlight banner to avoid being covered by the header

## Testing
- not run (environment issue installing dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68e578ac2960832ab3b401b67deee5b7